### PR TITLE
use canned recipe for compilation, add install/uninstall targets, turn on -Wall -Wextra

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,24 @@ Getting started
 
     make
 
+### Installing
+
+Install `cava` to default `/usr/local`:
+
+    make install
+
+Or you can change `PREFIX`, for example:
+
+    make PREFIX=$HOME/.local install
+
+### Uninstalling
+
+    make uninstall
+
+Or:
+
+    make PREFIX=$HOME/.local uninstall
+
 
 Capturing audio
 ---------------

--- a/makefile
+++ b/makefile
@@ -1,6 +1,25 @@
-cava: cava.c
-	gcc cava.c -o cava -lasound -lm -lfftw3 -lpthread
-clean:
-	rm cava
+CC       = gcc
+CFLAGS   = -Wall -Wextra
+CPPFLAGS =
+LDFLAGS  = -lasound -lm -lfftw3 -lpthread
 
-.PHONY: clean
+INSTALL     = install
+INSTALL_BIN = $(INSTALL) -D -m 755
+
+PREFIX ?= /usr/local
+BINDIR  = $(DESTDIR)/$(PREFIX)/bin
+
+all: cava
+
+cava: cava.c
+
+install: all
+	$(INSTALL_BIN) cava $(BINDIR)/cava
+
+uninstall:
+	$(RM) $(BINDIR)/cava
+
+clean:
+	$(RM) cava
+
+.PHONY: all clean install uninstall


### PR DESCRIPTION
I decided to make this PR since it wouldn't involve the coding style of the C.

A few extra notes: I didn't include commonly use `-g -O2` since they were not here previously. You (@karlstav) can put it into `CFLAGS` if you want, so for `-std=c99` if you decide to go for that.

Two targets: `install` and `uninstall` are added for installation.

The only thing really change is `-Wall -Wextra`, lots of warnings. If you'd like me to help clean up those warnings once coding style (and C99) is decided and done..