### PR TITLE
set -std=c99 -D_POSIX_SOURCE -D _POSIX_C_SOURCE=200809L, fix warnings and errors

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 CC       = gcc
-CFLAGS   = -Wall -Wextra
-CPPFLAGS =
-LDLIBS  = -lasound -lm -lfftw3 -lpthread
+CFLAGS   = -std=c99 -Wall -Wextra
+CPPFLAGS = -D_POSIX_SOURCE -D _POSIX_C_SOURCE=200809L
+LDLIBS   = -lasound -lm -lfftw3 -lpthread
 
 INSTALL     = install
 INSTALL_BIN = $(INSTALL) -D -m 755


### PR DESCRIPTION
* Change type of `rate` to `unsigned` to match, now use 0 for the waiting.
* `sig_no` and `thr_id` are tagged with GCC unused attribute to suppress the warnings.
* Switch to `nanosleep`.

Here is the `make` output with `-std=c99` before fixes:

```
gcc -std=c99 -Wall -Wextra    cava.c  -lasound -lm -lfftw3 -lpthread -o cava
cava.c: In function 'sigint_handler':
cava.c:35:2: warning: implicit declaration of function 'sigaction' [-Wimplicit-function-declaration]
  sigaction(SIGINT, &old_action, NULL);
  ^
cava.c:36:2: warning: implicit declaration of function 'kill' [-Wimplicit-function-declaration]
  kill(0, SIGINT);
  ^
cava.c:26:25: warning: unused parameter 'sig_no' [-Wunused-parameter]
 void sigint_handler(int sig_no)
                         ^
cava.c: In function 'music':
cava.c:61:2: warning: implicit declaration of function 'alloca' [-Wimplicit-function-declaration]
  snd_pcm_hw_params_alloca(&params);//assembling params
  ^
cava.c:89:2: warning: pointer targets in passing argument 2 of 'snd_pcm_hw_params_get_rate' differ in signedness [-Wpointer-sign]
  snd_pcm_hw_params_get_rate( params, &rate, &dir); //getting rate
  ^
In file included from /usr/include/alsa/asoundlib.h:54:0,
                 from cava.c:4:
/usr/include/alsa/pcm.h:739:5: note: expected 'unsigned int *' but argument is of type 'int *'
 int snd_pcm_hw_params_get_rate(const snd_pcm_hw_params_t *params, unsigned int *val, int *dir);
     ^
cava.c:95:9: warning: pointer targets in assignment differ in signedness [-Wpointer-sign]
  buffer = (char *) malloc(size);
         ^
cava.c: In function 'fifomusic':
cava.c:162:6: warning: unused variable 'i' [-Wunused-variable]
  int i, q;
      ^
cava.c:158:6: warning: unused variable 'fifo' [-Wunused-variable]
  int fifo;
      ^
cava.c: In function 'main':
cava.c:324:19: error: storage size of 'action' isn't known
  struct sigaction action;
                   ^
cava.c:337:4: warning: implicit declaration of function 'usleep' [-Wimplicit-function-declaration]
    usleep(1000);
    ^
cava.c:324:19: warning: unused variable 'action' [-Wunused-variable]
  struct sigaction action;
                   ^
cava.c:221:9: warning: unused variable 'sum' [-Wunused-variable]
  double sum = 0;
         ^
cava.c:217:26: warning: unused variable 'err' [-Wunused-variable]
  int i, n, o, size, dir, err, bw, width, height, c, rest, virt, fixedbands;
                          ^
cava.c:217:21: warning: unused variable 'dir' [-Wunused-variable]
  int i, n, o, size, dir, err, bw, width, height, c, rest, virt, fixedbands;
                     ^
cava.c:217:15: warning: unused variable 'size' [-Wunused-variable]
  int i, n, o, size, dir, err, bw, width, height, c, rest, virt, fixedbands;
               ^
cava.c:201:13: warning: variable 'thr_id' set but not used [-Wunused-but-set-variable]
  int        thr_id;
             ^
<builtin>: recipe for target 'cava' failed
make: *** [cava] Error 1
```