### PR TITLE
Merge livi's key controls patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,3 +212,10 @@ Usage
 Exit with ctrl+c.
 
 If cava quits unexpectedly or is force killed, echo must be turned on manually with `stty -echo`.
+
+### Controls
+
+| Key | Description |
+| --- | ----------- |
+| `s` | Toggle Scientific mode |
+| `q` or `CTRL-C`| Quit C.A.V.A. |


### PR DESCRIPTION
For #20. Was testing locally.

A bug I noticed is that if I start cava with `-S` for scientific mode and press the <kbd>s</kbd>-key to switch it to smoothed mode, the bars max out completely instead of showing smoothed bars. (This doesn't happen if you start in smoothed mode and use <kbd>s</kbd> to switch to scientific.)