### PR TITLE
Portable ncurses build

### DIFF
--- a/cava.c
+++ b/cava.c
@@ -21,7 +21,7 @@
 #include <time.h>
 #include <getopt.h>
 #include <pthread.h>
-#include "ncursesw/curses.h"
+#include <curses.h>
 #include <wchar.h>
 
 

--- a/makefile
+++ b/makefile
@@ -5,7 +5,7 @@ CC       = gcc
 CFLAGS   = -std=c99 -Wall -Wextra
 CPPFLAGS = -DPACKAGE=\"$(PACKAGE)\" -DVERSION=\"$(VERSION)\" \
            -D_POSIX_SOURCE -D _POSIX_C_SOURCE=200809L
-LDLIBS   = -lasound -lm -lfftw3 -lpthread -lncursesw
+LDLIBS   = -lasound -lm -lfftw3 -lpthread $(shell ncursesw5-config --cflags --libs)
 
 INSTALL     = install
 INSTALL_BIN = $(INSTALL) -D -m 755


### PR DESCRIPTION
Got myself a Debian VPS for this…

I [previously](https://github.com/karlstav/cava/issues/4#issuecomment-102623327) didn't pass `--cflags` to `ncursesw-config`.
Turns out that's all that was needed.
It's quite underwhelming really.

Compiles on Arch, Debian 7 and Fedora. Fixes karlstav/cava#4.

@karlstav Could you check functionality? I only checked it compiles; ALSA loopback is a hassle.