### PR TITLE
Color Argument Changes

### DIFF
--- a/cava.c
+++ b/cava.c
@@ -367,7 +367,7 @@ Options:\n\
 				}
 				break;
 			case 'c': // argument: foreground color
-				col = 0;
+				col = -2;
 				color = optarg;
 				if (strcmp(color, "black") == 0) col = 0;
 				if (strcmp(color, "red") == 0) col = 1;
@@ -377,13 +377,13 @@ Options:\n\
 				if (strcmp(color, "magenta") == 0) col = 5;
 				if (strcmp(color, "cyan") == 0) col = 6;
 				if (strcmp(color, "white") == 0) col = 7;
-				if (col == 0) {	
+				if (col == -2) {	
 					fprintf(stderr, "color %s not supported\n", color);
 					exit(EXIT_FAILURE);
 				}
 				break;
 			case 'C': // argument: background color
-				bgcol = 0;
+				bgcol = -2;
 				color = optarg;
 				if (strcmp(color, "black") == 0) bgcol = 0;
 				if (strcmp(color, "red") == 0) bgcol = 1;
@@ -393,7 +393,7 @@ Options:\n\
 				if (strcmp(color, "magenta") == 0) bgcol = 5;
 				if (strcmp(color, "cyan") == 0) bgcol = 6;
 				if (strcmp(color, "white") == 0) bgcol = 7;
-				if (bgcol == 0) {	
+				if (bgcol == -2) {	
 					fprintf(stderr, "color %s not supported\n", color);
 					exit(EXIT_FAILURE);
 				}

--- a/cava.c
+++ b/cava.c
@@ -393,7 +393,7 @@ Options:\n\
 				if (strcmp(color, "magenta") == 0) bgcol = 5;
 				if (strcmp(color, "cyan") == 0) bgcol = 6;
 				if (strcmp(color, "white") == 0) bgcol = 7;
-				if (strcmp(color, "none") == 0) bgcol = -1;
+				if (strcmp(color, "default") == 0) bgcol = -1;
 				if (bgcol == -2) {	
 					fprintf(stderr, "color %s not supported\n", color);
 					exit(EXIT_FAILURE);

--- a/cava.c
+++ b/cava.c
@@ -393,6 +393,7 @@ Options:\n\
 				if (strcmp(color, "magenta") == 0) bgcol = 5;
 				if (strcmp(color, "cyan") == 0) bgcol = 6;
 				if (strcmp(color, "white") == 0) bgcol = 7;
+				if (strcmp(color, "none") == 0) bgcol = -1;
 				if (bgcol == -2) {	
 					fprintf(stderr, "color %s not supported\n", color);
 					exit(EXIT_FAILURE);
@@ -459,8 +460,10 @@ Options:\n\
 	timeout(0);
 	noecho();
 	start_color();			
+	use_default_colors();
 	init_pair(1, col, bgcol);
-	bkgd(COLOR_PAIR(1));
+	if(bgcol != -1)
+		bkgd(COLOR_PAIR(1));
 	attron(COLOR_PAIR(1));
 	attron(A_BOLD);
 


### PR DESCRIPTION
I have added 'default' as a new value for the background color argument, which retains the default background color. This is useful for terminal emulators implementing transparency. Additionally, I modified the color argument handling to properly accept 'black.'