### PR TITLE
Added error handling for when config cant be accessed

### DIFF
--- a/cava.c
+++ b/cava.c
@@ -113,12 +113,12 @@ void load_config()
 	// config: create empty file
 	strcat(configPath, configFile);
 	FILE *fp = fopen(configPath, "ab+");
-    if (fp) {
-        fclose(fp);
-    } else {
-        printf("Unable to access config '%s', exiting...\n", configPath);
+	if (fp) {
+		fclose(fp);
+	} else {
+		print("Unable to access config '%s', exiting...\n", configPath);
 		exit(EXIT_FAILURE);
-    }
+	}
 
 	// config: parse ini
 	dictionary* ini = iniparser_load(configPath);

--- a/cava.c
+++ b/cava.c
@@ -113,7 +113,12 @@ void load_config()
 	// config: create empty file
 	strcat(configPath, configFile);
 	FILE *fp = fopen(configPath, "ab+");
-	fclose(fp);
+    if (fp) {
+        fclose(fp);
+    } else {
+        printf("Unable to access config '%s', exiting...\n", configPath);
+		exit(EXIT_FAILURE);
+    }
 
 	// config: parse ini
 	dictionary* ini = iniparser_load(configPath);


### PR DESCRIPTION
I had initially installed as sudo, causing the default configuration folder to be owned by root. When running Cava, this resulted in a segmentation fault. This can be fixed by modifying ownership easily, however it was not readily apparent this was the cause. I added some error handling to when the configuration is opened to make it more apparent for users.