### PR TITLE
add stdint header for compilation in Raspbian

### DIFF
--- a/output/raw.c
+++ b/output/raw.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 
 int print_raw_out(int bars, int fp, int is_bin, int bit_format, int ascii_range, char bar_delim, char frame_delim, int f[200]) {


### PR DESCRIPTION
In Raspbian (and perhaps in other systems) there is a compilation error if stdint.h is not included in output/raw.c, because otherwise the int types are not defined (uint8_t and uint16_t).