### PR TITLE
Add support for more colors in ncurses output. WIP for #91

### DIFF
--- a/output/terminal_ncurses.c
+++ b/output/terminal_ncurses.c
@@ -17,12 +17,20 @@ struct cols {
 
 struct cols parse_color(char *col) {
 	struct cols ret;
-	// Hexvalues
-	if (col[0] == '#') {
+	int has_colors = 0;
+	if (has_colors() == TRUE) {
+		has_colors = 1;
+	}
+	// Only use the hexvalues if we are certain that the terminal
+	// supports color redefinition, otherwise use default colours.
+	if (col[0] == '#' && has_colors == 1) {
 		// Set to -2 to indicate color_redefinition
 		ret.col = -2;
 		++col;
 		sscanf(col, "%02x%02x%02x", &ret.R, &ret.G, &ret.B);
+		return ret;
+	} else if (col[0] == '#' && has_colors == 0) {
+		ret.col = -1;
 		return ret;
 	}
 

--- a/output/terminal_ncurses.h
+++ b/output/terminal_ncurses.h
@@ -1,5 +1,5 @@
 
-int init_terminal_ncurses(int col, int bgcol);
+int init_terminal_ncurses(char *color, char *bcolor);
 void get_terminal_dim_ncurses(int *w, int *h);
 int draw_terminal_ncurses(int virt, int height, int width, int bars, int bw, int bs, int rest, int f[200], int flastd[200]);
 void cleanup_terminal_ncurses(void);


### PR DESCRIPTION
WIP for #91 

**NOTE: This breaks the `b` and `c` keys for cycling through the colors
in ncurses mode.**

Added a new function in cava.c `int validate_color(char
*colourToValidate, int outputMode)` which returns 1 if the colour is
valid, 0 otherwise.

Validation is done to ensure that HTML colours are of the form `#xxxxxx` or a
named ncurses colour is present.

HTML colours are allowed only when output mode is ncurses (ie `om = 1 ||
om = 2`). HTML and named colours can be mixed.

If the output mode is other than ncurses, the old method of setting
`bgcol` and `col` will be used.

Added a function in `terminal_ncurses.c` called `struct cols
parse_color(char *col)` which returns a struct containing:
1. `col`: The ncurses colour number parsed.
2. `R`, `G` and `B`: Integers that represent the R, G and B values
   parsed.

The `init_terminal_ncurses()` method now accepts two character pointers
instead of integers. The pointers contain color names (either HTML or
ncurses names) which are then parsed by the parse function defined
above.

Currently there is no check to find if the terminal supports color
redefinition or not. According to the parsed value we decide whether to
perform redefinition or use the predefined ncurses colours.

Ncurses colours 1 and 2 are redefined for foreground and background
respectively. This means that upon exiting, all the occurrences of 1 and
2 would have been redefined. To fix the colours back to the original the
user has to open another terminal.
