### PR TITLE
Add font directory environment variable

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,7 +15,7 @@ cava_CPPFLAGS = -DPACKAGE=\"$(PACKAGE)\" -DVERSION=\"$(VERSION)\" \
            -D_POSIX_SOURCE -D _POSIX_C_SOURCE=200809L
 cava_CFLAGS = -std=c99 -Wall -Wextra -Wno-unused-result -Wno-maybe-uninitialized 
 
-cava_font_dir = /usr/share/consolefonts
+cava_font_dir = @FONT_DIR@
 cava_font__DATA = cava.psf
 
 if !SYSTEM_LIBINIPARSER

--- a/configure.ac
+++ b/configure.ac
@@ -149,6 +149,14 @@ AS_IF([test "x$enable_legacy_iniparser" = "xyes"], [
   CPPFLAGS="$CPPFLAGS -DLEGACYINIPARSER"
 ])
 
+dnl ############################
+dnl Set font directory
+dnl ############################
+DEFAULT_FONT_DIR="/usr/share/consolefonts"
+AC_ARG_VAR(FONT_DIR, [Directory where the font will be installed.])
+if test -z "$FONT_DIR" ; then
+  FONT_DIR="$DEFAULT_FONT_DIR"
+fi
 
 
 


### PR DESCRIPTION
Adds a variable to specify the location where the font will be installed.

In this patch I chose to use /usr/share/consolefonts as the default,
though on my openSUSE system it will be /usr/share/kbd/consolefonts.
Maybe it varies between distros, so its good to have a variable.

Example usage:
FONT_DIR="/usr/share/kbd/consolefonts" ./configure && make && make install

Fixes https://github.com/karlstav/cava/issues/147