### PR TITLE
[#157] Update CAVA to work on Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,11 @@ config.status
 config.sub
 configure
 depcomp
+iniparser/.libs
+iniparser/libiniparser.la
 iniparser/Makefile
 iniparser/Makefile.in
-iniparser/src/.deps
+iniparser/src
 install-sh
 libtool
 ltmain.sh

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ cava
 *.so.0
 *.o
 *.a
+
+# Compiled files
+ltmain.sh
+m4
+version

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,25 @@ cava
 *.a
 
 # Compiled files
+.deps
+aclocal.m4
+ar-lib
+autom4te.cache
+compile
+config.guess
+config.log
+config.status
+config.sub
+configure
+depcomp
+iniparser/Makefile
+iniparser/Makefile.in
+iniparser/src/.deps
+install-sh
+libtool
 ltmain.sh
 m4
+Makefile
+Makefile.in
+missing
 version

--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ Fedora:
 
     dnf install alsa-lib-devel ncurses-devel fftw3-devel pulseaudio-libs-devel libtool
 
+macOS:
+
+    brew install autoconf automake fftw libtool ncurses
 
 Iniparser is also required, but if it is not already installed, a bundled version will be used.
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -7,9 +7,9 @@ else
 fi
 
 if libtoolize 2>/dev/null; then
-  exit 1
+  libtoolize
 elif glibtoolize 2>/dev/null; then
-  exit 1
+  glibtoolize
 else
   echo 'Missing libtoolize'
   exit 1

--- a/autogen.sh
+++ b/autogen.sh
@@ -6,7 +6,14 @@ else
   echo 0.4.2 > version # hard coded versions
 fi
 
-libtoolize
+if libtoolize 2>/dev/null; then
+  exit 1
+elif glibtoolize 2>/dev/null; then
+  exit 1
+else
+  echo 'Missing libtoolize'
+  exit 1
+fi
 aclocal
 autoconf
 automake --add-missing

--- a/cava.c
+++ b/cava.c
@@ -787,8 +787,8 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
 		pr =  fftw_plan_dft_r2c_1d(M, inr, *outr, FFTW_MEASURE); 
 	}
 
-	bool reloadConf = FALSE;
-	bool senseLow = TRUE;
+	bool reloadConf = false;
+	bool senseLow = true;
 
 	while  (!reloadConf) {//jumbing back to this loop means that you resized the screen
 		for (i = 0; i < 200; i++) {
@@ -925,7 +925,7 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
 	
 		if (stereo) bars = bars * 2; 	
 
-	   	bool resizeTerminal = FALSE;
+	   	bool resizeTerminal = false;
 
 		while  (!resizeTerminal) {
 
@@ -943,11 +943,11 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
 					break;
 				case 68:    // key right
 					bw++;
-					resizeTerminal = TRUE;
+					resizeTerminal = true;
 					break;
 				case 67:    // key left
 					if (bw > 1) bw--;
-					resizeTerminal = TRUE;
+					resizeTerminal = true;
 					break;
 				case 'm':
 					if (mode == modes) {
@@ -962,12 +962,12 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
 				case 'c': //change forground color
 					if (col < 7) col++;
 					else col = 0;
-					resizeTerminal = TRUE;
+					resizeTerminal = true;
 					break;
 				case 'b': //change backround color
 					if (bgcol < 7) bgcol++;
 					else bgcol = 0;
-					resizeTerminal = TRUE;
+					resizeTerminal = true;
 					break;
 
 				case 'q':
@@ -980,8 +980,8 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
 				audio.terminate = 1;
 				pthread_join( p_thread, NULL);
 
-				reloadConf = TRUE;
-				resizeTerminal = TRUE;
+				reloadConf = true;
+				resizeTerminal = true;
 				should_reload = 0;
 
 			}
@@ -1115,7 +1115,7 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
 			if (autosens && om != 4) {
 				for (o = 0; o < bars; o++) {
 					if (f[o] > height * 8 + height * 8 * overshoot / 100) {
-						senseLow = FALSE;
+						senseLow = false;
 						sens = sens * 0.99;
 						break;
 					}
@@ -1144,7 +1144,7 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
 						break;
 				}
 
-				if (rc == -1) resizeTerminal = TRUE; //terminal has been resized breaking to recalibrating values
+				if (rc == -1) resizeTerminal = true; //terminal has been resized breaking to recalibrating values
 
 				if (framerate <= 1) {
 					req.tv_sec = 1  / (float)framerate;


### PR DESCRIPTION
## Notes
⚠️ This PR is a work in progress. **DO NOT MERGE.** ⚠️

I've added conditionals around the build scripts to verify that we're using the right tools for Linux vs macOS. Next up is attempting to clean up all of the errors being thrown in `cava.c`.

## TODO
### `autogen.sh`
- [x] Use `glibtoolize` on macOS
- [x] Cleanup `glibtoolize` errors
  - [x] glibtoolize: Consider adding 'AC_CONFIG_MACRO_DIRS([m4])' to configure.ac, and rerunning glibtoolize and aclocal.
### `cava.c`
- [ ] Clean up `iniparser` errors
- [ ] Clean up `Unknown warning option` errors
- [x] Clean up `undeclared identifier` errors