### PR TITLE
Update Arch commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Debian/Raspbian:
 
 ArchLinux:
 
-    pacman -S base-devel fftw ncurses
+    pacman -S base-devel fftw ncurses alsa-lib iniparser pulseaudio
 
 openSUSE:
 
@@ -138,7 +138,7 @@ If you use another version just replace *openSUSE_Leap_42.2* with *openSUSE_13.2
 
 Cava is in [AUR](https://aur.archlinux.org/packages/cava/).
 
-    yaourt -S cava
+    pacaur -S cava
 
 ### Ubuntu
 


### PR DESCRIPTION
2 Modifications:

1. Update build requirements according to the official [AUR package](https://aur.archlinux.org/packages/cava/).
2. Because `yaourt` is not safe (Please report to [the documentation](https://aur.archlinux.org/packages/cava/)), I updated the command from `yaourt` to `pacaur` which is, according to official Arch Linux Wiki and forums discussions, safer, more clear and more reliable than `yaourt`.