### PR TITLE
Add sndio backend

### DIFF
--- a/cava.c
+++ b/cava.c
@@ -1,5 +1,5 @@
 #define _XOPEN_SOURCE_EXTENDED
-#include <alloca.h>
+#include <stdlib.h>
 #include <locale.h>
 #include <stdio.h>
 #include <stddef.h>
@@ -51,6 +51,10 @@
 #ifdef PULSE
 #include "input/pulse.h"
 #include "input/pulse.c"
+#endif
+
+#ifdef SNDIO
+#include "input/sndio.c"
 #endif
 
 #include <iniparser.h>
@@ -287,6 +291,9 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
     #ifdef PULSE
         strcat(supportedInput,", 'pulse'");
     #endif
+    #ifdef SNDIO
+        strcat(supportedInput,", 'sndio'");
+    #endif
 
 	//fft: planning to rock
 	fftw_complex outl[M / 2 + 1][2];
@@ -384,6 +391,13 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
 		else sourceIsAuto = 0;
 		//starting pulsemusic listener
 		thr_id = pthread_create(&p_thread, NULL, input_pulse, (void*)&audio); 
+		audio.rate = 44100;
+	}
+	#endif
+
+	#ifdef SNDIO
+	if (p.im == 4) {
+		thr_id = pthread_create(&p_thread, NULL, input_sndio, (void*)&audio);
 		audio.rate = 44100;
 	}
 	#endif

--- a/config.c
+++ b/config.c
@@ -87,6 +87,13 @@ if (strcmp(inputMethod, "pulse") == 0) {
         #endif
 
 }
+if (strcmp(inputMethod, "sndio") == 0) {
+	p->im = 4;
+	#ifndef SNDIO
+		fprintf(stderr, "cava was built without sndio support\n");
+		exit(EXIT_FAILURE);
+	#endif
+}
 if (p->im == 0) {
 	fprintf(stderr,
 		"input method '%s' is not supported, supported methods are: %s\n",
@@ -325,6 +332,10 @@ inputMethod = (char *)iniparser_getstring(ini, "input:method", "fifo");
 	inputMethod = (char *)iniparser_getstring(ini, "input:method", "pulse");
 #endif
 
+//setting sndio to defaualt if supported
+#ifdef SNDIO
+	inputMethod = (char *)iniparser_getstring(ini, "input:method", "sndio");
+#endif
 
 #ifdef NCURSES
 	outputMethod = (char *)iniparser_getstring(ini, "output:method", "ncurses");
@@ -401,6 +412,10 @@ if (strcmp(inputMethod, "fifo") == 0) {
 if (strcmp(inputMethod, "pulse") == 0) {
 	p->im = 3;
 	p->audio_source = (char *)iniparser_getstring(ini, "input:source", "auto");
+}
+if (strcmp(inputMethod, "sndio") == 0) {
+	p->im = 4;
+	p->audio_source = (char *)iniparser_getstring(ini, "input:source", SIO_DEVANY);
 }
 
 validate_config(supportedInput, params);

--- a/config.c
+++ b/config.c
@@ -413,10 +413,12 @@ if (strcmp(inputMethod, "pulse") == 0) {
 	p->im = 3;
 	p->audio_source = (char *)iniparser_getstring(ini, "input:source", "auto");
 }
+#ifdef SNDIO
 if (strcmp(inputMethod, "sndio") == 0) {
 	p->im = 4;
 	p->audio_source = (char *)iniparser_getstring(ini, "input:source", SIO_DEVANY);
 }
+#endif
 
 validate_config(supportedInput, params);
 //iniparser_freedict(ini);

--- a/configure.ac
+++ b/configure.ac
@@ -65,6 +65,19 @@ AC_CHECK_LIB(pulse-simple, pa_simple_new, have_pulse=yes, have_pulse=no)
     fi
 
 dnl ######################
+dnl checking for sndio dev
+dnl ######################
+AC_CHECK_LIB(sndio, sio_open, have_sndio=yes, have_sndio=no)
+    if [[ $have_sndio = "yes" ]] ; then
+      LIBS="$LIBS -lsndio"
+      CPPFLAGS="$CPPFLAGS -DSNDIO"
+    fi
+
+    if [[ $have_sndio = "no" ]] ; then
+      AC_MSG_NOTICE([WARNING: No sndio dev files found building without sndio support])
+    fi
+
+dnl ######################
 dnl checking for math lib
 dnl ######################
 AC_CHECK_LIB(m, sqrt, have_m=yes, have_m=no)

--- a/input/sndio.c
+++ b/input/sndio.c
@@ -1,0 +1,63 @@
+#include <assert.h>
+#include <errno.h>
+#include <sndio.h>
+#include <string.h>
+
+void* input_sndio(void* data)
+{
+	struct audio_data *audio = (struct audio_data *)data;
+	struct sio_par par;
+	struct sio_hdl *hdl;
+	int16_t buf[256];
+	unsigned int i, n, channels;
+
+	assert(audio->channels > 0);
+	channels = audio->channels;
+
+	sio_initpar(&par);
+	par.sig = 1;
+	par.bits = 16;
+	par.le = 1;
+	par.rate = 44100;
+	par.rchan = channels;
+	par.appbufsz = sizeof(buf) / channels;
+
+	if ((hdl = sio_open(audio->source, SIO_REC, 0)) == NULL) {
+		fprintf(stderr, __FILE__": Could not open sndio source: %s\n", audio->source);
+		exit(EXIT_FAILURE);
+	}
+
+	if (!sio_setpar(hdl, &par) || !sio_getpar(hdl, &par) || par.sig != 1 || par.le != 1 || par.rate != 44100 || par.rchan != channels) {
+		fprintf(stderr, __FILE__": Could not set required audio parameters\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (!sio_start(hdl)) {
+		fprintf(stderr, __FILE__": sio_start() failed\n");
+		exit(EXIT_FAILURE);
+	}
+
+	n = 0;
+	while (audio->terminate != 1) {
+		if (sio_read(hdl, buf, sizeof(buf)) == 0) {
+			fprintf(stderr, __FILE__": sio_read() failed: %s\n", strerror(errno));
+			exit(EXIT_FAILURE);
+		}
+
+		for (i = 0; i < sizeof(buf)/sizeof(buf[0]); i += 2) {
+			if (par.rchan == 1) {
+				// sndiod has already taken care of averaging the samples
+				audio->audio_out_l[n] = buf[i];
+			} else if (par.rchan == 2) {
+				audio->audio_out_l[n] = buf[i];
+				audio->audio_out_r[n] = buf[i + 1];
+			}
+			n = (n + 1) % 2048;
+		}
+	}
+
+	sio_stop(hdl);
+	sio_close(hdl);
+
+	return 0;
+}


### PR DESCRIPTION
This adds an [sndio](http://www.sndio.org/) backend to cava.

sndio is the audio framework used on OpenBSD, but it's also available on
FreeBSD and Linux.  So far I only tested it on FreeBSD.

To test it
```bash
# Start sndiod with a monitor sub-device
$ sndiod -dd -s default -m mon -s monitor

# Set the AUDIODEVICE environment variable to override the default
# sndio device and run cava
$ AUDIODEVICE=snd/0.monitor cava
```
