### PR TITLE
Enabled multicolored gradient

### DIFF
--- a/cava.c
+++ b/cava.c
@@ -454,7 +454,7 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
 		//output: start ncurses mode
 		if (p.om == 1 || p.om ==  2) {
 			init_terminal_ncurses(p.color, p.bcolor, p.col,
-			p.bgcol, p.gradient, p.gradient_color_1, p.gradient_color_2,&w, &h);
+			p.bgcol, p.gradient, p.gradient_count, p.gradient_colors,&w, &h);
 			//get_terminal_dim_ncurses(&w, &h);
 		}
 		#endif

--- a/config.c
+++ b/config.c
@@ -11,13 +11,13 @@ char *inputMethod, *outputMethod, *channels;
 
 struct config_params {
 
-char *color, *bcolor, *raw_target, *audio_source, *gradient_color_1, *gradient_color_2, *data_format;
+char *color, *bcolor, *raw_target, *audio_source, /**gradient_color_1, *gradient_color_2,*/ **gradient_colors, *data_format;
 char bar_delim, frame_delim ;
 double monstercat, integral, gravity, ignore, sens; 
 unsigned int lowcf, highcf;
 double *smooth;
 int smcount, customEQ, im, om, col, bgcol, autobars, stereo, is_bin, ascii_range,
- bit_format, gradient, fixedbars, framerate, bw, bs, autosens, overshoot, waves;
+ bit_format, gradient, gradient_count, fixedbars, framerate, bw, bs, autosens, overshoot, waves;
 
 };
 
@@ -214,13 +214,11 @@ if (!validate_color(p->bcolor, p->om)) {
 }
 
 if (p->gradient) {
-    if (!validate_color(p->gradient_color_1, p->om)) {
-	    fprintf(stderr, "The first gradient color is invalid. It must be HTML color of the form '#xxxxxx'.\n");
-	    exit(EXIT_FAILURE);
-    }
-    if (!validate_color(p->gradient_color_2, p->om)) {
-	    fprintf(stderr, "The second gradient color is invalid. It must be HTML color of the form '#xxxxxx'.\n");
-	    exit(EXIT_FAILURE);
+    for(int i = 0;i < p->gradient_count;i++){
+        if (!validate_color(p->gradient_colors[i], p->om)) {
+	        fprintf(stderr, "The first gradient color is invalid. It must be HTML color of the form '#xxxxxx'.\n");
+	        exit(EXIT_FAILURE);
+        }
     }
 }
 
@@ -360,8 +358,27 @@ p->bcolor = (char *)iniparser_getstring(ini, "color:background", "default");
 
 p->gradient = iniparser_getint(ini, "color:gradient", 0);
 if (p->gradient) {
-	p->gradient_color_1 = (char *)iniparser_getstring(ini, "color:gradient_color_1", "#0099ff");
-	p->gradient_color_2 = (char *)iniparser_getstring(ini, "color:gradient_color_2", "#ff3399");
+    p->gradient_count = iniparser_getint(ini, "color:gradient_count", 2);
+	if(p->gradient_count < 2){
+	    printf("\nAtleast two colors must be given as gradient!\n");
+	    exit(EXIT_FAILURE);
+	}
+	if(p->gradient_count > 8){
+	    printf("\nMaximum 8 colors can be specified as gradient!\n");
+	    exit(EXIT_FAILURE);
+	}
+	p->gradient_colors = (char **)malloc(sizeof(char*) * p->gradient_count);
+    for(int i = 0;i < p->gradient_count;i++){
+        char ini_config[23];
+        sprintf(ini_config, "color:gradient_color_%d", (i + 1));
+        p->gradient_colors[i] = (char *)iniparser_getstring(ini, ini_config, NULL);
+        if(p->gradient_colors[i] == NULL){
+            printf("\nGradient color not specified : gradient_color_%d\n", (i + 1));
+            exit(EXIT_FAILURE);
+        }
+    }
+    //p->gradient_color_1 = (char *)iniparser_getstring(ini, "color:gradient_color_1", "#0099ff");
+	//p->gradient_color_2 = (char *)iniparser_getstring(ini, "color:gradient_color_2", "#ff3399");
 }
 
 p->fixedbars = iniparser_getint(ini, "general:bars", 0);

--- a/example_files/config
+++ b/example_files/config
@@ -102,7 +102,8 @@
 # Gradient mode, only hex defined colors are supported, background must also be defined in hex
 # or remain commented out. 1 = on, 0 = off. Warning: for certain terminal emulators cava will
 # not able to restore color definitions on exit, simply restart your terminal to restore colors.
-; gradient = 0
+; gradient = 1
+; gradient_count = 2
 ; gradient_color_1 = '#0099ff'
 ; gradient_color_2 = '#ff3399'
 

--- a/output/terminal_ncurses.h
+++ b/output/terminal_ncurses.h
@@ -1,6 +1,6 @@
 void init_terminal_ncurses(char* const fg_color_string,
 	char* const bg_color_string, int predef_fg_color, int predef_bg_color, int gradient,
- char* const gradient_color_1, char* const gradient_color_2,int* width, int* height);
+ int gradient_count, char **gradient_colors,int* width, int* height);
 void get_terminal_dim_ncurses(int* width, int* height);
 int draw_terminal_ncurses(int is_tty, int terminal_height, int terminal_width,
 	int bars_count, int bar_width, int bar_spacing, int rest, const int f[200],


### PR DESCRIPTION
Now, the option to configure gradient with more than 2 colors is
supported. To use this, write the following in your config :
```
gradient = 1
gradient_count = <num>
gradient_color_1 = <col>
gradient_color_2 = <col>
gradient_color_3 = <col>
.
.
.
gradient_color_<num> = <col>
```
Replace `<num>` with the number of colors (2 <= colors <= 8), and replace
 `<col>`s with your colors of choice. You must explicitly provide all
 colors for the gradient to work, otherwise appropriate errors will be
 shown.

Also, the default value for `gradient_count` is 2 when absent. Hence all old configs will be valid too.