### PR TITLE
Update documentation to highlight raw output, link to config file, closes #254

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,9 @@ exit with ctrl+z then run 'bg' to keep it running after you log out.
 
 (You must be root to redirect to console. Simple sudo is not enough: Run `sudo su` first.)
 
+### Raw Output
 
+You can also use Cava's output for other programs by using raw output mode, which will write bar data to `STDOUT` that can be piped into other processes. More information on this option is documented in [the example config file](/example_files/config).
 
 Font notes
 ----------
@@ -325,7 +327,9 @@ Configuration
 
 As of version 0.4.0 all options are done in the config file, no more command-line arguments!
 
-By default a configuration file is located in `$XDG_CONFIG_HOME/cava/config` or `$HOME/.config/cava/config`, but cava can also be made to use a different file with the `-p` option. Look in the default config file for details on the different options.
+By default a configuration file is located in `$XDG_CONFIG_HOME/cava/config` or `$HOME/.config/cava/config`, but cava can also be made to use a different file with the `-p` option.
+
+Use the [default configuration file](/example_files/config), which is heavily commented, as a reference for available options.
 
 Sending cava a SIGUSR1 signal, will force cava to reload its configuration file. Thus, it behaves as if the user pressed <kbd>r</kbd> in the terminal. One might send a SIGUSR1 signal using `pkill` or `killall`.
 For example:

--- a/example_files/config
+++ b/example_files/config
@@ -66,8 +66,8 @@
 
 # Ouput method. Can be 'ncurses', 'noncurses' or 'raw'. 
 # 'noncurses' is for systems that does not suport ncurses.
-# 'raw' is an 8 or 16 bit (configurable via 'bit_format' option) data stream of
-# the bar heights that can be used to send to other applications.
+# 'raw' is an 8 or 16 bit (configurable via the 'bit_format' option) data
+# stream of the bar heights that can be used to send to other applications.
 # 'raw' defaults to 200 bars, which can be adjusted in the 'bars' option above.
 ; method = ncurses
 

--- a/example_files/config
+++ b/example_files/config
@@ -66,7 +66,8 @@
 
 # Ouput method. Can be 'ncurses', 'noncurses' or 'raw'. 
 # 'noncurses' is for systems that does not suport ncurses.
-# 'raw' is a 16 bit data stream of the bar heights that can be used to send to other applications.
+# 'raw' is an 8 or 16 bit (configurable via 'bit_format' option) data stream of
+# the bar heights that can be used to send to other applications.
 # 'raw' defaults to 200 bars, which can be adjusted in the 'bars' option above.
 ; method = ncurses
 


### PR DESCRIPTION
Also makes the minor correction to the comment about 8 bit data in raw
output mode in the config file mentioned by @karlstav in #254.

This is, of course, open to any revision. I tried to follow your (very helpful) comments in #254, while also providing a small addition that highlights raw output mode. It's purely because, for me, it seems like a fairly big deal: it took me a while to find something that could give me programmatic visualizer data, and this is a big boon to people working on electronics projects.

Happy to make any revisions. Again: this project has been an enormous help to me. I really appreciate the time and effort you put into making it, and especially your responsiveness to the users who requested raw output mode in the first place.
