### PR TITLE
Allow FIFO input sample rate to be configurable

### DIFF
--- a/cava.c
+++ b/cava.c
@@ -461,7 +461,7 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
 	if (p.im == 2) {
 		//starting fifomusic listener
 		thr_id = pthread_create(&p_thread, NULL, input_fifo, (void*)&audio);
-		audio.rate = 44100;
+		audio.rate = p.fifoSample;
 	}
 
 	#ifdef PULSE

--- a/config.c
+++ b/config.c
@@ -13,7 +13,7 @@ double monstercat, integral, gravity, ignore, sens;
 unsigned int lowcf, highcf;
 double *smooth;
 int smcount, customEQ, im, om, col, bgcol, autobars, stereo, is_bin, ascii_range,
- bit_format, gradient, gradient_count, fixedbars, framerate, bw, bs, autosens, overshoot, waves, FFTbufferSize;
+ bit_format, gradient, gradient_count, fixedbars, framerate, bw, bs, autosens, overshoot, waves, FFTbufferSize, fifoSample;
 
 };
 
@@ -510,6 +510,7 @@ if (strcmp(inputMethod, "alsa") == 0) {
 if (strcmp(inputMethod, "fifo") == 0) {
 	p->im = 2;
 	p->audio_source = (char *)iniparser_getstring(ini, "input:source", "/tmp/mpd.fifo");
+	p->fifoSample = iniparser_getint(ini, "input:sample_rate", 44100);
 }
 if (strcmp(inputMethod, "pulse") == 0) {
 	p->im = 3;


### PR DESCRIPTION
Refs #275.

While it was mentioned that the ability to acquire this information from MPD would be useful, allowing it to be configured explicitly could help when FIFO is used for non-MPD sources.

For example, I am currently running Cava inside Windows Subsystem for Linux with a program on the Windows side feeding the capture of the system audio output into Cava, and it would be really useful to be able to handle 48 kHz audio as that is the default format on Windows.