### PR TITLE
Use NDEBUG for debugging and add debug print helper

### DIFF
--- a/cava.c
+++ b/cava.c
@@ -31,6 +31,8 @@
 #include <dirent.h>
 #include <ctype.h>
 
+#include "debug.h"
+
 #ifdef NCURSES
 #include "output/terminal_ncurses.h"
 #include "output/terminal_ncurses.c"
@@ -361,9 +363,7 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
 	// general: main loop
 	while (1) {
 
-	#ifdef DEBUG
-		printf("loading config\n");
-	#endif
+	debug("loading config\n");
 	//config: load
 	struct error_s error;
 	error.length = 0;
@@ -416,9 +416,7 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
 	audio.treble_index = 0;
 
 
-	#ifdef DEBUG
-		printf("starting audio thread\n");
-	#endif
+	debug("starting audio thread\n");
 	#ifdef ALSA
 	// input_alsa: wait for the input to be ready
 	if (p.im == 1) {
@@ -451,9 +449,7 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
 				exit(EXIT_FAILURE);
 			}
 		}
-	#ifdef DEBUG
-		printf("got format: %d and rate %d\n", audio.format, audio.rate);
-	#endif
+	debug("got format: %d and rate %d\n", audio.format, audio.rate);
 
 	}
 	#endif
@@ -540,10 +536,8 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
 	fftw_plan p_treble_l =  fftw_plan_dft_r2c_1d(audio.FFTtreblebufferSize, in_treble_l, out_treble_l, FFTW_MEASURE);
 	fftw_plan p_treble_r =  fftw_plan_dft_r2c_1d(audio.FFTtreblebufferSize, in_treble_r, out_treble_r, FFTW_MEASURE);
 
-	#ifdef DEBUG
-		printf("got buffer size: %d, %d, %d", audio.FFTbassbufferSize, audio.FFTmidbufferSize, audio.FFTtreblebufferSize);
-		printf("zeroing buffers\n");
-	#endif
+	debug("got buffer size: %d, %d, %d", audio.FFTbassbufferSize, audio.FFTmidbufferSize, audio.FFTtreblebufferSize);
+	debug("zeroing buffers\n");
 	for (i = 0; i < (audio.FFTbassbufferSize / 2 + 1); i++) {
 		if (i < audio.FFTbassbufferSize) {
 			audio.audio_out_bass_l[i] = 0;
@@ -687,7 +681,7 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
 		rest = (w - bars * p.bw - bars * p.bs + p.bs) / 2;
 		if (rest < 0)rest = 0;
 
-		#ifdef DEBUG
+		#ifndef NDEBUG
 			printw("height: %d width: %d bars:%d bar width: %d rest: %d\n",
 						 w,
 						 h, bars, p.bw, rest);
@@ -768,7 +762,7 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
 				hcf[n - 1] = lcf[n] - 1;
 			}
 
-#ifdef DEBUG
+#ifndef NDEBUG
 			if (n != 0) {
 				mvprintw(n,0,"%d: %f -> %f (%d -> %d) bass: %d, treble:%d \n", n,
 						fc[n - 1], fc[n], lcf[n - 1],
@@ -851,7 +845,7 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
 
 			//if (cont == 0) break;
 
-			#ifdef DEBUG
+			#ifndef NDEBUG
 				//clear();
 				refresh();
 			#endif
@@ -1020,13 +1014,11 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
 			if (p.autosens && !silence && senselow) p.sens = p.sens * 1.001;
 
 
-			#ifdef DEBUG
-				//printf("%d\n",maxvalue); //checking maxvalue 10000
-			#endif
+			//debug("%d\n",maxvalue); //checking maxvalue 10000
 
 			
 			// output: draw processed input
-			#ifndef DEBUG
+			#ifdef NDEBUG
 				switch (p.om) {
 					case 1:
 						#ifdef NCURSES

--- a/configure.ac
+++ b/configure.ac
@@ -18,9 +18,9 @@ AC_ARG_ENABLE([debug],
     [enable debug messages and frequency table output])
 )
 
-AS_IF([test "x$enable_debug" = "xyes"], [
+AS_IF([test "x$enable_debug" != "xyes"], [
   dnl enabling debug mode
-  CPPFLAGS="$CPPFLAGS -DDEBUG"
+  CPPFLAGS="$CPPFLAGS -DNDEBUG"
 ])
 
 

--- a/debug.h
+++ b/debug.h
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+#ifdef NDEBUG
+#define debug(...) do { } while (0)
+#else
+#define debug(...) fprintf(stderr, __VA_ARGS__)
+#endif

--- a/input/alsa.c
+++ b/input/alsa.c
@@ -12,9 +12,7 @@ snd_pcm_uframes_t* frames) {
 		fprintf(stderr, "error opening stream: %s\n", snd_strerror(err));
 		exit(EXIT_FAILURE);
 	}
-	#ifdef DEBUG
-		else printf("open stream successful\n");
-	#endif
+	else debug("open stream successful\n");
 
 	snd_pcm_hw_params_t* params;
 	snd_pcm_hw_params_alloca(&params); // assembling params
@@ -145,18 +143,12 @@ void* input_alsa(void* data) {
 
 		if (err == -EPIPE) {
 			/* EPIPE means overrun */
-#ifdef DEBUG
-			fprintf(stderr, "overrun occurred\n");
-#endif
+			debug("overrun occurred\n");
 			snd_pcm_prepare(handle);
 		} else if (err < 0) {
-#ifdef DEBUG
-			fprintf(stderr, "error from read: %s\n", snd_strerror(err));
-#endif
+			debug("error from read: %s\n", snd_strerror(err));
 		} else if (err != (int)frames) {
-#ifdef DEBUG
-			fprintf(stderr, "short read, read %d %d frames\n", err, (int)frames);
-#endif
+			debug("short read, read %d %d frames\n", err, (int)frames);
 		}
 
 


### PR DESCRIPTION
This PR is split up in two parts.

First, usage of `DEBUG` is remapped to `NDEBUG`, such that the behaviour of assert(3) is as expected with --enable-debug=false (i.e. asserts get disabled, where they previously did not).

Second, instances of `printf` guarded by `#ifdef DEBUG` blocks have been refactored into a dedicated `debug` macro to make the code a bit easier to follow. `debug` is a no-op when `NDEBUG` is set.