### PR TITLE
ncurses: silence `setterm` errors on exit

### DIFF
--- a/output/terminal_ncurses.c
+++ b/output/terminal_ncurses.c
@@ -243,7 +243,7 @@ void cleanup_terminal_ncurses(void) {
 	echo();
 	system("setfont  >/dev/null 2>&1");
 	system("setfont /usr/share/consolefonts/Lat2-Fixed16.psf.gz  >/dev/null 2>&1");
-	system("setterm -blank 10");
+	system("setterm -blank 10  >/dev/null 2>&1");
 	/*for(int i = 0; i < gradient_size; ++i) {
 		if(the_color_redefinitions[i].color) {
 			init_color(the_color_redefinitions[i].color,


### PR DESCRIPTION
`setterm` can fail, in which case cava exits with something like:

> setterm: terminal rxvt-unicode-256color does not support --blank

This commit silences the potential error.