### PR TITLE
Add --enable-asan flag to ./configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,16 @@ AS_IF([test "x$enable_debug" != "xyes"], [
   CPPFLAGS="$CPPFLAGS -DNDEBUG"
 ])
 
+AC_ARG_ENABLE([asan],
+  AS_HELP_STRING([--enable-asan],
+    [build with AddressSanitizer])
+)
+
+AS_IF([test "x$enable_asan" = "xyes"], [
+  dnl enabling asan
+  CPPFLAGS="$CPPFLAGS -fsanitize=address"
+  LDFLAGS="$LDFLAGS -fsanitize=address"
+])
 
 
 dnl ######################


### PR DESCRIPTION
Refs #306.

This appears to already be finding bugs, like this one on startup:

```
=================================================================
==20534==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6040000002b8 at pc 0x7f451cea0ccd bp 0x7ffff7da6b60 sp 0x7ffff7da6b58
READ of size 8 at 0x6040000002b8 thread T0
    #0 0x7f451cea0ccc in main /home/quantum/build/cava/cava.c:683
    #1 0x7f451ba0409a in __libc_start_main ../csu/libc-start.c:308
    #2 0x7f451cea0db9 in _start (/home/quantum/build/cava/cava+0xadb9)

0x6040000002b8 is located 0 bytes to the right of 40-byte region [0x604000000290,0x6040000002b8)
allocated by thread T0 here:
    #0 0x7f451c169330 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xe9330)
    #1 0x7f451cea7270 in load_config /home/quantum/build/cava/config.c:488
    #2 0x7f451ce9ceea in main /home/quantum/build/cava/cava.c:371

SUMMARY: AddressSanitizer: heap-buffer-overflow /home/quantum/build/cava/cava.c:683 in main
Shadow bytes around the buggy address:
  0x0c087fff8000: fa fa 00 00 00 00 05 fa fa fa 00 00 00 00 00 fa
  0x0c087fff8010: fa fa fd fd fd fd fd fa fa fa fd fd fd fd fd fa
  0x0c087fff8020: fa fa fd fd fd fd fd fd fa fa fd fd fd fd fd fd
  0x0c087fff8030: fa fa 00 00 00 00 00 fa fa fa fd fd fd fd fd fd
  0x0c087fff8040: fa fa fd fd fd fd fd fd fa fa fd fd fd fd fd fd
=>0x0c087fff8050: fa fa 00 00 00 00 00[fa]fa fa 00 00 00 00 00 fa
  0x0c087fff8060: fa fa 00 00 00 00 00 00 fa fa fd fd fd fd fd fd
  0x0c087fff8070: fa fa 00 00 00 00 00 06 fa fa 00 00 00 00 00 06
  0x0c087fff8080: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c087fff8090: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c087fff80a0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==20534==ABORTING
```