### PR TITLE
Use loop exit condition in place of always true

### DIFF
--- a/input/alsa.c
+++ b/input/alsa.c
@@ -116,7 +116,7 @@ void* input_alsa(void* data) {
 	//const int size = frames * (audio->format / 8) * CHANNELS_COUNT;
 	signed char* buffer = malloc(period_size);
 
-	while (1) {
+	while (!audio->terminate) {
 		switch (audio->format) {
 			case 16:
 				err = snd_pcm_readi(handle, buf, frames);
@@ -153,12 +153,9 @@ void* input_alsa(void* data) {
 
 
 		write_to_fftw_input_buffers(buf, frames, data);
-
-
-		if (audio->terminate == 1) {
-			free(buffer);
-			snd_pcm_close(handle);
-			return NULL;
-		}
 	}
+
+	free(buffer);
+	snd_pcm_close(handle);
+	return NULL;
 }

--- a/input/fifo.c
+++ b/input/fifo.c
@@ -91,7 +91,7 @@ void* input_fifo(void* data)
 
 	fd = open_fifo(audio->source);
 
-	while (1) {
+	while (!audio->terminate) {
 
 		bytes = read(fd, buf, sizeof(buf));
 
@@ -114,13 +114,8 @@ void* input_fifo(void* data)
 
 			write_to_fftw_input_buffers(buf, frames, audio);
 		}
-
-		if (audio->terminate == 1) {
-			close(fd);
-			break;
-		}
-
 	}
 
+	close(fd);
 	return 0;
 }

--- a/input/pulse.c
+++ b/input/pulse.c
@@ -146,7 +146,7 @@ void* input_pulse(void* data) {
 	}
 
 
-	while (1) {
+	while (!audio->terminate) {
         	if (pa_simple_read(s, buf, sizeof(buf), &error) < 0) {
             		sprintf(audio->error_message, __FILE__": pa_simple_read() failed: %s\n",
 			pa_strerror(error));
@@ -157,12 +157,8 @@ void* input_pulse(void* data) {
 		 //sorting out channels
 
 		write_to_fftw_input_buffers(buf, frames, data);
+	}
 
-		if (audio->terminate == 1) {            		
-			pa_simple_free(s);
-			break;
-		}
-        }
-
+	pa_simple_free(s);
 	return 0;
 }

--- a/input/shmem.c
+++ b/input/shmem.c
@@ -59,7 +59,7 @@ void* input_shmem(void* data)
 	// printf("bufs: %u / run: %u / rate: %u\n",mmap_area->buf_size, mmap_area->running, mmap_area->rate);
 	audio->rate = mmap_area->rate;
 
-	while (1) {
+	while (!audio->terminate) {
 		write_to_fftw_input_buffers(mmap_area->buffer, BUFSIZE, audio);
 /*
 		for (i = VB_OFFSET; i < BUFSIZE+VB_OFFSET; i += 2) {
@@ -73,9 +73,6 @@ void* input_shmem(void* data)
 			if (n == audio->FFTbufferSize - 1) n = 0;
 		}
 */
-		if (audio->terminate == 1) {
-			break;
-		}
 	}
 
 	// cleanup


### PR DESCRIPTION
This PR proposes a minor change to when loops are exited, in hopes that it makes tracking when resources are freed easier to track.