### PR TITLE
Add support for 24- and 32-bit FIFO input

### DIFF
--- a/cava.c
+++ b/cava.c
@@ -414,6 +414,7 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
             // starting fifomusic listener
             thr_id = pthread_create(&p_thread, NULL, input_fifo, (void *)&audio);
             audio.rate = p.fifoSample;
+            audio.format = p.fifoSampleBits;
             break;
 #ifdef PULSE
         case INPUT_PULSE:

--- a/config.c
+++ b/config.c
@@ -483,6 +483,7 @@ bool load_config(char configPath[255], struct config_params *p, bool colorsOnly,
     case INPUT_FIFO:
         p->audio_source = strdup(iniparser_getstring(ini, "input:source", "/tmp/mpd.fifo"));
         p->fifoSample = iniparser_getint(ini, "input:sample_rate", 44100);
+        p->fifoSampleBits = iniparser_getint(ini, "input:sample_bits", 16);
         break;
 #ifdef PULSE
     case INPUT_PULSE:

--- a/config.h
+++ b/config.h
@@ -58,7 +58,7 @@ struct config_params {
     enum input_method im;
     int smcount, customEQ, om, col, bgcol, autobars, stereo, is_bin, ascii_range, bit_format,
         gradient, gradient_count, fixedbars, framerate, bw, bs, autosens, overshoot, waves,
-        FFTbufferSize, fifoSample;
+        FFTbufferSize, fifoSample, fifoSampleBits;
 };
 
 struct error_s {

--- a/input/common.c
+++ b/input/common.c
@@ -1,5 +1,14 @@
 #include "input/common.h"
 
+void reset_output_buffers(struct audio_data *data) {
+    memset(data->audio_out_bass_r, 0, sizeof(int16_t) * data->FFTbassbufferSize);
+    memset(data->audio_out_bass_l, 0, sizeof(int16_t) * data->FFTbassbufferSize);
+    memset(data->audio_out_mid_r, 0, sizeof(int16_t) * data->FFTmidbufferSize);
+    memset(data->audio_out_mid_l, 0, sizeof(int16_t) * data->FFTmidbufferSize);
+    memset(data->audio_out_treble_r, 0, sizeof(int16_t) * data->FFTtreblebufferSize);
+    memset(data->audio_out_treble_l, 0, sizeof(int16_t) * data->FFTtreblebufferSize);
+}
+
 int write_to_fftw_input_buffers(int16_t buf[], int16_t frames, void *data) {
     struct audio_data *audio = (struct audio_data *)data;
 

--- a/input/common.h
+++ b/input/common.h
@@ -26,4 +26,6 @@ struct audio_data {
     char error_message[1024];
 };
 
+void reset_output_buffers(struct audio_data *data);
+
 int write_to_fftw_input_buffers(int16_t buf[], int16_t frames, void *data);

--- a/input/fifo.c
+++ b/input/fifo.c
@@ -1,11 +1,14 @@
 #include "input/fifo.h"
 #include "input/common.h"
 
+#include <stdlib.h>
+#include <string.h>
+
 #include <fcntl.h>
 #include <time.h>
 #include <unistd.h>
 
-#define BUFSIZE 1024
+#define SAMPLES_PER_BUFFER 512
 
 int open_fifo(const char *path) {
     int fd = open(path, O_RDONLY);
@@ -17,32 +20,65 @@ int open_fifo(const char *path) {
 // input: FIFO
 void *input_fifo(void *data) {
     struct audio_data *audio = (struct audio_data *)data;
-    int time_since_last_input = 0;
-    int bytes = 0;
-    int16_t buf[BUFSIZE / 2];
+    int bytes_per_sample = audio->format / 8;
+    uint8_t buf[SAMPLES_PER_BUFFER * bytes_per_sample];
+    uint16_t *samples =
+        bytes_per_sample == 2 ? (uint16_t *)&buf : calloc(SAMPLES_PER_BUFFER, sizeof(uint16_t));
 
     int fd = open_fifo(audio->source);
 
     while (!audio->terminate) {
-        bytes = read(fd, buf, sizeof(buf));
+        int time_since_last_input = 0;
+        unsigned int offset = 0;
+        do {
+            int num_read = read(fd, buf + offset, sizeof(buf) - offset);
 
-        if (bytes < 1) { // if no bytes read sleep 10ms and zero shared buffer
-            nanosleep(&(struct timespec){.tv_sec = 0, .tv_nsec = 10000000}, NULL);
-            time_since_last_input++;
-            if (time_since_last_input > 10) {
-                reset_output_buffers(audio);
-                close(fd);
+            if (num_read < 1) { // if no bytes read sleep 10ms and zero shared buffer
+                nanosleep(&(struct timespec){.tv_sec = 0, .tv_nsec = 10000000}, NULL);
+                time_since_last_input++;
 
-                fd = open_fifo(audio->source);
+                if (time_since_last_input > 10) {
+                    reset_output_buffers(audio);
+                    close(fd);
+
+                    fd = open_fifo(audio->source);
+                    time_since_last_input = 0;
+                    offset = 0;
+                }
+            } else {
+                offset += num_read;
                 time_since_last_input = 0;
             }
-        } else { // if bytes read go ahead
-            time_since_last_input = 0;
+        } while (offset < sizeof(buf));
 
-            write_to_fftw_input_buffers(buf, BUFSIZE / 4, audio);
+        switch (bytes_per_sample) {
+        case 2:
+            // [samples] = [buf] so there's nothing to do here.
+            break;
+        case 3:
+            for (int i = 0; i < SAMPLES_PER_BUFFER; i++) {
+                // Really, a sample is composed of buf[3i + 2] | buf[3i + 1] | buf[3i], but our FFT
+                // only takes 16-bit samples. Since we need to scale them eventually, we can just
+                // do so here by taking the top 2 bytes.
+                samples[i] = (buf[3 * i + 2] << 8) | buf[3 * i + 1];
+            }
+            break;
+        case 4:
+            for (int i = 0; i < SAMPLES_PER_BUFFER; i++) {
+                samples[i] = (buf[4 * i + 3] << 8) | buf[4 * i + 2];
+            }
+            break;
         }
+
+        // We worked with unsigned ints up until now to save on sign extension, but the FFT wants
+        // signed ints.
+        write_to_fftw_input_buffers((int16_t *)samples, SAMPLES_PER_BUFFER / 2, audio);
     }
 
     close(fd);
+    if (bytes_per_sample == 2) {
+        free(samples);
+    }
+
     return 0;
 }

--- a/input/fifo.c
+++ b/input/fifo.c
@@ -6,8 +6,6 @@
 #include <unistd.h>
 
 #define BUFSIZE 1024
-#define MAX_FFTBUFERSIZE
-int rc;
 
 int open_fifo(const char *path) {
     int fd = open(path, O_RDONLY);
@@ -19,44 +17,29 @@ int open_fifo(const char *path) {
 // input: FIFO
 void *input_fifo(void *data) {
     struct audio_data *audio = (struct audio_data *)data;
-    int fd;
-    int i;
-    int t = 0;
+    int time_since_last_input = 0;
     int bytes = 0;
     int16_t buf[BUFSIZE / 2];
-    struct timespec req = {.tv_sec = 0, .tv_nsec = 10000000};
-    uint16_t frames = BUFSIZE / 4;
 
-    fd = open_fifo(audio->source);
+    int fd = open_fifo(audio->source);
 
     while (!audio->terminate) {
-
         bytes = read(fd, buf, sizeof(buf));
 
         if (bytes < 1) { // if no bytes read sleep 10ms and zero shared buffer
-            nanosleep(&req, NULL);
-            t++;
-            if (t > 10) {
-                for (i = 0; i < audio->FFTbassbufferSize; i++)
-                    audio->audio_out_bass_l[i] = 0;
-                for (i = 0; i < audio->FFTbassbufferSize; i++)
-                    audio->audio_out_bass_r[i] = 0;
-                for (i = 0; i < audio->FFTmidbufferSize; i++)
-                    audio->audio_out_mid_l[i] = 0;
-                for (i = 0; i < audio->FFTmidbufferSize; i++)
-                    audio->audio_out_mid_r[i] = 0;
-                for (i = 0; i < audio->FFTtreblebufferSize; i++)
-                    audio->audio_out_treble_l[i] = 0;
-                for (i = 0; i < audio->FFTtreblebufferSize; i++)
-                    audio->audio_out_treble_r[i] = 0;
+            nanosleep(&(struct timespec){.tv_sec = 0, .tv_nsec = 10000000}, NULL);
+            time_since_last_input++;
+            if (time_since_last_input > 10) {
+                reset_output_buffers(audio);
                 close(fd);
+
                 fd = open_fifo(audio->source);
-                t = 0;
+                time_since_last_input = 0;
             }
         } else { // if bytes read go ahead
-            t = 0;
+            time_since_last_input = 0;
 
-            write_to_fftw_input_buffers(buf, frames, audio);
+            write_to_fftw_input_buffers(buf, BUFSIZE / 4, audio);
         }
     }
 


### PR DESCRIPTION
Refs #293.

This also fixes a possible bug with 16-bit audio: if `read` spuriously returns having read less than a multiple of 2 bytes, the stream could get unsynced forever. I think this is unlikely for 16-bit samples, but happens *very* frequently with 24-bit samples. (This is fixed by simply waiting until the entire sample buffer is full before proceeding.)

(This PR is based off of #318, I will rebase it if/when that one is approved.)