### PR TITLE
Use PATH_MAX instead of hardcoding 255

### DIFF
--- a/cava.c
+++ b/cava.c
@@ -244,7 +244,7 @@ int main(int argc, char **argv) {
     double k[200];
     float g;
     struct timespec req = {.tv_sec = 0, .tv_nsec = 0};
-    char configPath[255];
+    char configPath[PATH_MAX];
     char *usage = "\n\
 Usage : " PACKAGE " [options]\n\
 Visualize audio input in terminal. \n\

--- a/config.c
+++ b/config.c
@@ -341,7 +341,7 @@ bool load_colors(struct config_params *p, dictionary *ini, void *err) {
     return true;
 }
 
-bool load_config(char configPath[255], struct config_params *p, bool colorsOnly,
+bool load_config(char configPath[PATH_MAX], struct config_params *p, bool colorsOnly,
                  struct error_s *error) {
     FILE *fp;
 

--- a/config.h
+++ b/config.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <limits.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
@@ -66,5 +67,5 @@ struct error_s {
     int length;
 };
 
-bool load_config(char configPath[255], struct config_params *p, bool colorsOnly,
+bool load_config(char configPath[PATH_MAX], struct config_params *p, bool colorsOnly,
                  struct error_s *error);

--- a/input/common.c
+++ b/input/common.c
@@ -1,5 +1,7 @@
 #include "input/common.h"
 
+#include <string.h>
+
 void reset_output_buffers(struct audio_data *data) {
     memset(data->audio_out_bass_r, 0, sizeof(int16_t) * data->FFTbassbufferSize);
     memset(data->audio_out_bass_l, 0, sizeof(int16_t) * data->FFTbassbufferSize);


### PR DESCRIPTION
This saves potential errors when a config is in some deeply-nested directory. `PATH_MAX` tends to be ~4096 on most systems.