### PR TITLE
De-duplicate falloff memory assignment

### DIFF
--- a/cava.c
+++ b/cava.c
@@ -1005,9 +1005,7 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
                 nanosleep(&req, NULL);
 #endif
 
-                for (o = 0; o < bars; o++) {
-                    flastd[o] = f[o];
-                }
+                memcpy(flastd, f, 200 * sizeof(int));
 
                 // checking if audio thread has exited unexpectedly
                 if (audio.terminate == 1) {

--- a/output/terminal_ncurses.c
+++ b/output/terminal_ncurses.c
@@ -249,8 +249,6 @@ int draw_terminal_ncurses(int is_tty, int terminal_height, int terminal_width, i
         }
     }
 
-    memcpy(flastd, f, sizeof(*f)); // Memory for falloff func
-
     refresh();
     return 0;
 }


### PR DESCRIPTION
I got it wrong in `output/terminal_ncurses.c`, but it was hidden by the copy being done again in `cava.c`.