### PR TITLE
Add --enable-tsan to build with ThreadSanitizer

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,6 +35,18 @@ AS_IF([test "x$enable_asan" = "xyes"], [
 ])
 
 
+AC_ARG_ENABLE([ubsan],
+  AS_HELP_STRING([--enable-ubsan],
+    [build with UndefinedBehaviorSanitizer])
+)
+
+AS_IF([test "x$enable_ubsan" = "xyes"], [
+  dnl enabling ubsan
+  CPPFLAGS="$CPPFLAGS -fsanitize=undefined"
+  LDFLAGS="$LDFLAGS -fsanitize=undefined"
+])
+
+
 dnl ######################
 dnl checking for pthread
 dnl ######################

--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,16 @@ AS_IF([test "x$enable_asan" = "xyes"], [
   LDFLAGS="$LDFLAGS -fsanitize=address"
 ])
 
+AC_ARG_ENABLE([tsan],
+  AS_HELP_STRING([--enable-tsan],
+    [build with ThreadSanitizer])
+)
+
+AS_IF([test "x$enable_tsan" = "xyes"], [
+  dnl enabling tsan
+  CPPFLAGS="$CPPFLAGS -fsanitize=thread"
+  LDFLAGS="$LDFLAGS -fsanitize=thread"
+])
 
 AC_ARG_ENABLE([ubsan],
   AS_HELP_STRING([--enable-ubsan],


### PR DESCRIPTION
Refs #327. Note: this PR is based on #325 and should be merged after that one.

TSan reported the following data races:

```
==================
WARNING: ThreadSanitizer: data race (pid=5020)
  Read of size 2 at 0x7fffe4dbd5e8 by main thread:
    #0 main /home/quantum/build/cava/cava.c:808 (cava+0x5136)

  Previous write of size 2 at 0x7fffe4dbd5e8 by thread T1:
    #0 write_to_fftw_input_buffers input/common.c:21 (cava+0x9605)
    #1 input_fifo input/fifo.c:59 (cava+0x998b)
    #2 <null> <null> (libtsan.so.0+0x29b3d)

  Location is stack of main thread.

  Location is global '<null>' at 0x000000000000 ([stack]+0x00000073e5e8)

  Thread T1 (tid=5022, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x2be1b)
    #1 main /home/quantum/build/cava/cava.c:429 (cava+0x6aa5)

SUMMARY: ThreadSanitizer: data race /home/quantum/build/cava/cava.c:808 in main
==================
==================
WARNING: ThreadSanitizer: data race (pid=5020)
  Read of size 2 at 0x7fffe4ddd5ea by main thread:
    #0 main /home/quantum/build/cava/cava.c:806 (cava+0x50ff)

  Previous write of size 2 at 0x7fffe4ddd5ea by thread T1:
    #0 write_to_fftw_input_buffers input/common.c:20 (cava+0x95c5)
    #1 input_fifo input/fifo.c:59 (cava+0x998b)
    #2 <null> <null> (libtsan.so.0+0x29b3d)

  Location is stack of main thread.

  Location is global '<null>' at 0x000000000000 ([stack]+0x00000075e5ea)

  Thread T1 (tid=5022, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x2be1b)
    #1 main /home/quantum/build/cava/cava.c:429 (cava+0x6aa5)

SUMMARY: ThreadSanitizer: data race /home/quantum/build/cava/cava.c:806 in main
==================
==================
WARNING: ThreadSanitizer: data race (pid=5020)
  Read of size 2 at 0x7fffe4e1d5e8 by main thread:
    #0 main /home/quantum/build/cava/cava.c:820 (cava+0x54bf)

  Previous write of size 2 at 0x7fffe4e1d5e8 by thread T1:
    #0 write_to_fftw_input_buffers input/common.c:28 (cava+0x969d)
    #1 input_fifo input/fifo.c:59 (cava+0x998b)
    #2 <null> <null> (libtsan.so.0+0x29b3d)

  Location is stack of main thread.

  Location is global '<null>' at 0x000000000000 ([stack]+0x00000079e5e8)

  Thread T1 (tid=5022, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x2be1b)
    #1 main /home/quantum/build/cava/cava.c:429 (cava+0x6aa5)

SUMMARY: ThreadSanitizer: data race /home/quantum/build/cava/cava.c:820 in main
==================
==================
WARNING: ThreadSanitizer: data race (pid=5020)
  Read of size 2 at 0x7fffe4dfd5e8 by main thread:
    #0 main /home/quantum/build/cava/cava.c:822 (cava+0x54f4)

  Previous write of size 2 at 0x7fffe4dfd5e8 by thread T1:
    #0 write_to_fftw_input_buffers input/common.c:23 (cava+0x962d)
    #1 input_fifo input/fifo.c:59 (cava+0x998b)
    #2 <null> <null> (libtsan.so.0+0x29b3d)

  Location is stack of main thread.

  Location is global '<null>' at 0x000000000000 ([stack]+0x00000077e5e8)

  Thread T1 (tid=5022, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x2be1b)
    #1 main /home/quantum/build/cava/cava.c:429 (cava+0x6aa5)

SUMMARY: ThreadSanitizer: data race /home/quantum/build/cava/cava.c:822 in main
==================
==================
WARNING: ThreadSanitizer: data race (pid=5020)
  Read of size 2 at 0x7fffe4e5d5e8 by main thread:
    #0 main /home/quantum/build/cava/cava.c:832 (cava+0x55ef)

  Previous write of size 2 at 0x7fffe4e5d5e8 by thread T1:
    #0 write_to_fftw_input_buffers input/common.c:29 (cava+0x96b2)
    #1 input_fifo input/fifo.c:59 (cava+0x998b)
    #2 <null> <null> (libtsan.so.0+0x29b3d)

  Location is stack of main thread.

  Location is global '<null>' at 0x000000000000 ([stack]+0x0000007de5e8)

  Thread T1 (tid=5022, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x2be1b)
    #1 main /home/quantum/build/cava/cava.c:429 (cava+0x6aa5)

SUMMARY: ThreadSanitizer: data race /home/quantum/build/cava/cava.c:832 in main
==================
==================
WARNING: ThreadSanitizer: data race (pid=5020)
  Read of size 2 at 0x7fffe4e3d5e8 by main thread:
    #0 main /home/quantum/build/cava/cava.c:834 (cava+0x5624)

  Previous write of size 2 at 0x7fffe4e3d5e8 by thread T1:
    #0 write_to_fftw_input_buffers input/common.c:24 (cava+0x964c)
    #1 input_fifo input/fifo.c:59 (cava+0x998b)
    #2 <null> <null> (libtsan.so.0+0x29b3d)

  Location is stack of main thread.

  Location is global '<null>' at 0x000000000000 ([stack]+0x0000007be5e8)

  Thread T1 (tid=5022, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x2be1b)
    #1 main /home/quantum/build/cava/cava.c:429 (cava+0x6aa5)

SUMMARY: ThreadSanitizer: data race /home/quantum/build/cava/cava.c:834 in main
==================
==================
WARNING: ThreadSanitizer: data race (pid=5020)
  Write of size 2 at 0x7fffe4e1dde6 by thread T1:
    #0 input_fifo input/fifo.c:45 (cava+0x9a53)
    #1 <null> <null> (libtsan.so.0+0x29b3d)

  Previous read of size 2 at 0x7fffe4e1dde6 by main thread:
    #0 main /home/quantum/build/cava/cava.c:820 (cava+0x54bf)

  As if synchronized via sleep:
    #0 nanosleep <null> (libtsan.so.0+0x49960)
    #1 input_fifo input/fifo.c:37 (cava+0x999e)
    #2 <null> <null> (libtsan.so.0+0x29b3d)

  Location is stack of main thread.

  Location is global '<null>' at 0x000000000000 ([stack]+0x00000079ede6)

  Thread T1 (tid=5022, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x2be1b)
    #1 main /home/quantum/build/cava/cava.c:429 (cava+0x6aa5)

SUMMARY: ThreadSanitizer: data race input/fifo.c:45 in input_fifo
==================
==================
WARNING: ThreadSanitizer: data race (pid=5020)
  Write of size 2 at 0x7fffe4dfdde6 by thread T1:
    #0 input_fifo input/fifo.c:47 (cava+0x9a83)
    #1 <null> <null> (libtsan.so.0+0x29b3d)

  Previous read of size 2 at 0x7fffe4dfdde6 by main thread:
    #0 main /home/quantum/build/cava/cava.c:822 (cava+0x54f4)

  As if synchronized via sleep:
    #0 nanosleep <null> (libtsan.so.0+0x49960)
    #1 input_fifo input/fifo.c:37 (cava+0x999e)
    #2 <null> <null> (libtsan.so.0+0x29b3d)

  Location is stack of main thread.

  Location is global '<null>' at 0x000000000000 ([stack]+0x00000077ede6)

  Thread T1 (tid=5022, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x2be1b)
    #1 main /home/quantum/build/cava/cava.c:429 (cava+0x6aa5)

SUMMARY: ThreadSanitizer: data race input/fifo.c:47 in input_fifo
==================
==================
WARNING: ThreadSanitizer: data race (pid=5020)
  Write of size 2 at 0x7fffe4e5d9e6 by thread T1:
    #0 input_fifo input/fifo.c:49 (cava+0x9acb)
    #1 <null> <null> (libtsan.so.0+0x29b3d)

  Previous read of size 2 at 0x7fffe4e5d9e6 by main thread:
    #0 main /home/quantum/build/cava/cava.c:832 (cava+0x55ef)

  As if synchronized via sleep:
    #0 nanosleep <null> (libtsan.so.0+0x49960)
    #1 input_fifo input/fifo.c:37 (cava+0x999e)
    #2 <null> <null> (libtsan.so.0+0x29b3d)

  Location is stack of main thread.

  Location is global '<null>' at 0x000000000000 ([stack]+0x0000007de9e6)

  Thread T1 (tid=5022, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x2be1b)
    #1 main /home/quantum/build/cava/cava.c:429 (cava+0x6aa5)

SUMMARY: ThreadSanitizer: data race input/fifo.c:49 in input_fifo
==================
==================
WARNING: ThreadSanitizer: data race (pid=5020)
  Write of size 2 at 0x7fffe4e3d9e6 by thread T1:
    #0 input_fifo input/fifo.c:51 (cava+0x9afb)
    #1 <null> <null> (libtsan.so.0+0x29b3d)

  Previous read of size 2 at 0x7fffe4e3d9e6 by main thread:
    #0 main /home/quantum/build/cava/cava.c:834 (cava+0x5624)

  As if synchronized via sleep:
    #0 nanosleep <null> (libtsan.so.0+0x49960)
    #1 input_fifo input/fifo.c:37 (cava+0x999e)
    #2 <null> <null> (libtsan.so.0+0x29b3d)

  Location is stack of main thread.

  Location is global '<null>' at 0x000000000000 ([stack]+0x0000007be9e6)

  Thread T1 (tid=5022, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x2be1b)
    #1 main /home/quantum/build/cava/cava.c:429 (cava+0x6aa5)

SUMMARY: ThreadSanitizer: data race input/fifo.c:51 in input_fifo
==================
ThreadSanitizer: reported 10 warnings
```