### PR TITLE
add configure options to disable optional features

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -77,63 +77,94 @@ AC_CHECK_HEADER([alloca.h], [CPPFLAGS="$CPPFLAGS -DHAVE_ALLOCA_H"])
 dnl ######################
 dnl checking for alsa dev
 dnl ######################
-AC_CHECK_LIB(asound, snd_pcm_open, have_alsa=yes, have_alsa=no)
-    if [[ $have_alsa = "yes" ]] ; then
-      LIBS="$LIBS -lasound"
-      CPPFLAGS="$CPPFLAGS -DALSA"
-    fi
+AC_ARG_ENABLE([input_alsa],
+  AS_HELP_STRING([--disable-input-alsa],
+    [do not include support for input from alsa streams])
+)
 
-    if [[ $have_alsa = "no" ]] ; then
-      AC_MSG_NOTICE([WARNING: No alsa dev files found building without alsa support])
-    fi
+AS_IF([test "x$enable_input_alsa" != "xno"], [
+  AC_CHECK_LIB(asound, snd_pcm_open, have_alsa=yes, have_alsa=no)
+  if [[ $have_alsa = "yes" ]] ; then
+    LIBS="$LIBS -lasound"
+    CPPFLAGS="$CPPFLAGS -DALSA"
+  fi
+  if [[ $have_alsa = "no" ]] ; then
+    AC_MSG_NOTICE([WARNING: No alsa dev files found building without alsa support])
+  fi],
+  [have_alsa=no]
+)
 
-    AM_CONDITIONAL([ALSA], [test x$have_alsa = xyes])
+AM_CONDITIONAL([ALSA], [test "x$have_alsa" = "xyes"])
 
 
 dnl ######################
 dnl checking for pulse dev
 dnl ######################
-AC_CHECK_LIB(pulse-simple, pa_simple_new, have_pulse=yes, have_pulse=no)
-    if [[ $have_pulse = "yes" ]] ; then
-      LIBS="$LIBS -lpulse-simple -lpulse"
-      CPPFLAGS="$CPPFLAGS -DPULSE"
-    fi
+AC_ARG_ENABLE([input_pulse],
+  AS_HELP_STRING([--disable-input-pulse],
+    [do not include support for input from pulseaudio])
+)
 
-    if [[ $have_pulse = "no" ]] ; then
-      AC_MSG_NOTICE([WARNING: No pusleaudio dev files found building without pulseaudio support])
-    fi
+AS_IF([test "x$enable_input_pulse" != "xno"], [
+  AC_CHECK_LIB(pulse-simple, pa_simple_new, have_pulse=yes, have_pulse=no)
+  if [[ $have_pulse = "yes" ]] ; then
+    LIBS="$LIBS -lpulse-simple -lpulse"
+    CPPFLAGS="$CPPFLAGS -DPULSE"
+  fi
 
-    AM_CONDITIONAL([PULSE], [test x$have_pulse = xyes])
+  if [[ $have_pulse = "no" ]] ; then
+    AC_MSG_NOTICE([WARNING: No pusleaudio dev files found building without pulseaudio support])
+  fi],
+  [have_pulse=no]
+)
+
+AM_CONDITIONAL([PULSE], [test "x$have_pulse" = "xyes"])
 
 dnl ######################
 dnl checking for portaudio dev
 dnl ######################
-AC_CHECK_LIB(portaudio, Pa_Initialize, have_portaudio=yes, have_portaudio=no)
-    if [[ $have_portaudio = "yes" ]] ; then
-      LIBS="$LIBS -lportaudio"
-      CPPFLAGS="$CPPFLAGS -DPORTAUDIO"
-    fi
+AC_ARG_ENABLE([input_portaudio],
+  AS_HELP_STRING([--disable-input-portaudio],
+    [do not include support for input from portaudio])
+)
 
-    if [[ $have_portaudio = "no" ]] ; then
-      AC_MSG_NOTICE([WARNING: No portaudio dev files found building without portaudio support])
-    fi
+AS_IF([test "x$enable_input_portaudio" != "xno"], [
+  AC_CHECK_LIB(portaudio, Pa_Initialize, have_portaudio=yes, have_portaudio=no)
+  if [[ $have_portaudio = "yes" ]] ; then
+    LIBS="$LIBS -lportaudio"
+    CPPFLAGS="$CPPFLAGS -DPORTAUDIO"
+  fi
 
-    AM_CONDITIONAL([PORTAUDIO], [test x$have_portaudio = xyes])
+  if [[ $have_portaudio = "no" ]] ; then
+    AC_MSG_NOTICE([WARNING: No portaudio dev files found building without portaudio support])
+  fi],
+  [have_portaudio=no]
+)
+
+AM_CONDITIONAL([PORTAUDIO], [test "x$have_portaudio" = "xyes"])
 
 dnl ######################
 dnl checking for sndio dev
 dnl ######################
-AC_CHECK_LIB(sndio, sio_open, have_sndio=yes, have_sndio=no)
-    if [[ $have_sndio = "yes" ]] ; then
-      LIBS="$LIBS -lsndio"
-      CPPFLAGS="$CPPFLAGS -DSNDIO"
-    fi
+AC_ARG_ENABLE([input_sndio],
+  AS_HELP_STRING([--disable-input-sndio],
+    [do not include support for input from sndio])
+)
 
-    if [[ $have_sndio = "no" ]] ; then
-      AC_MSG_NOTICE([WARNING: No sndio dev files found building without sndio support])
-    fi
+AS_IF([test "x$enable_input_sndio" != "xno"], [
+  AC_CHECK_LIB(sndio, sio_open, have_sndio=yes, have_sndio=no)
+  if [[ $have_sndio = "yes" ]] ; then
+    LIBS="$LIBS -lsndio"
+    CPPFLAGS="$CPPFLAGS -DSNDIO"
+  fi
 
-    AM_CONDITIONAL([SNDIO], [test x$have_sndio = xyes])
+  if [[ $have_sndio = "no" ]] ; then
+    AC_MSG_NOTICE([WARNING: No sndio dev files found building without sndio support])
+  fi],
+  [have_portaudio=no]
+)
+
+AM_CONDITIONAL([SNDIO], [test "x$have_sndio" = "xyes"])
 
 dnl ######################
 dnl checking for math lib
@@ -163,57 +194,77 @@ AC_CHECK_LIB(fftw3,fftw_execute, have_fftw=yes, have_fftw=no)
 dnl ######################
 dnl checking for ncursesw
 dnl ######################
-curses_config_bin="ncursesw6-config ncursesw5-config"
-
-AC_PATH_PROGS(CURSES_CONFIG, $curses_config_bin)
-
-AC_CHECK_LIB(ncursesw, initscr,
-	curses_lib=ncursesw
+AC_ARG_ENABLE([output_ncurses],
+  AS_HELP_STRING([--disable-output-ncurses],
+    [do not include support for output with ncurses])
 )
 
-AC_CHECK_LIB($curses_lib, initscr,
-	if test "$CURSES_CONFIG" = "" ; then
-		LIBS="$LIBS -l$curses_lib"
-  		CPPFLAGS="$CPPFLAGS -DNCURSES"
-	fi
-	if test "$CURSES_CONFIG" != "" ; then
-		CPPFLAGS="$CPPFLAGS `$CURSES_CONFIG --cflags` -DNCURSES"
-		LIBS="$LIBS `$CURSES_CONFIG --libs`"
-	fi
-	AC_CHECK_HEADERS([curses.h], , AC_MSG_ERROR([missing curses.h header]))
-	AM_CONDITIONAL([NCURSES], [true])
-	,
-	AC_MSG_NOTICE([WARNING: building without ncursesw support ncursesw is recomended!])
-	AM_CONDITIONAL([NCURSES], [false])
-	)
+AS_IF([test "x$enable_output_ncurses" != "xno"], [
+  curses_config_bin="ncursesw6-config ncursesw5-config"
 
+  AC_PATH_PROGS(CURSES_CONFIG, $curses_config_bin)
+
+  AC_CHECK_LIB(ncursesw, initscr,
+    curses_lib=ncursesw
+  )
+
+  AC_CHECK_LIB($curses_lib, initscr,
+    if test "$CURSES_CONFIG" = "" ; then
+      LIBS="$LIBS -l$curses_lib"
+      CPPFLAGS="$CPPFLAGS -DNCURSES"
+    fi
+    if test "$CURSES_CONFIG" != "" ; then
+      CPPFLAGS="$CPPFLAGS `$CURSES_CONFIG --cflags` -DNCURSES"
+      LIBS="$LIBS `$CURSES_CONFIG --libs`"
+    fi
+
+    AC_CHECK_HEADERS([curses.h], , AC_MSG_ERROR([missing curses.h header]))
+    have_ncurses=yes,
+
+    AC_MSG_NOTICE([WARNING: building without ncursesw support ncursesw is recomended!])
+    have_ncurses=no
+  )],
+  [have_ncurses=no]
+)
+
+AM_CONDITIONAL([NCURSES], [test "x$have_ncurses" = "xyes"])
 
 
 dnl ######################
 dnl checking for system iniparser
 dnl ######################
 
-AC_SEARCH_LIBS([iniparser_load], [iniparser], [
-	AC_CHECK_HEADERS([iniparser.h], [have_system_iniparser=yes])
-])
-AM_CONDITIONAL([SYSTEM_LIBINIPARSER], [test "x$have_system_iniparser" = "xyes"])
-	if test "x$have_system_iniparser" = "xyes"; then
-	AC_SUBST(SYSTEM_LIBINIPARSER, 1)
-	AC_MSG_NOTICE([Using installed iniparser])
-        LIBS="$LIBS -liniparser"
-	AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <iniparser.h>]],
-			[[dictionary* ini;
-			const char *keys[3];
-			iniparser_getseckeys(ini, "eq", keys);]])],
-			[AC_MSG_RESULT(iniparser > 3.2 test OK)],
-			[AC_MSG_RESULT(iniparser > 3.2 test failed falling back to legacy iniparser mode)
-                        CPPFLAGS="$CPPFLAGS -DLEGACYINIPARSER"])
+AC_ARG_ENABLE([system_iniparser],
+  AS_HELP_STRING([--disable-system-iniparser],
+    [do not use system iniparser library (use bundled iniparser library)])
+)
 
-	else
-	AC_SUBST(SYSTEM_LIBINIPARSER, 0)
-	AC_CONFIG_FILES(iniparser/Makefile)
-	AC_MSG_NOTICE([Building iniparser])
-	fi
+AS_IF([test "x$enable_system_iniparser" != "xno"], [
+  AC_SEARCH_LIBS([iniparser_load], [iniparser], [
+    AC_CHECK_HEADERS([iniparser.h], [have_system_iniparser=yes])
+    ])
+  ],
+  [have_system_iniparser=no]
+)
+
+AM_CONDITIONAL([SYSTEM_LIBINIPARSER], [test "x$have_system_iniparser" = "xyes"])
+
+if test "x$have_system_iniparser" = "xyes"; then
+  AC_SUBST(SYSTEM_LIBINIPARSER, 1)
+  AC_MSG_NOTICE([Using installed iniparser])
+  LIBS="$LIBS -liniparser"
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <iniparser.h>]],
+    [[dictionary* ini;
+    const char *keys[3];
+    iniparser_getseckeys(ini, "eq", keys);]])],
+    [AC_MSG_RESULT(iniparser > 3.2 test OK)],
+    [AC_MSG_RESULT(iniparser > 3.2 test failed falling back to legacy iniparser mode)
+    CPPFLAGS="$CPPFLAGS -DLEGACYINIPARSER"])
+else
+  AC_SUBST(SYSTEM_LIBINIPARSER, 0)
+  AC_CONFIG_FILES(iniparser/Makefile)
+  AC_MSG_NOTICE([Building iniparser])
+fi
 
 
 dnl ############################


### PR DESCRIPTION
When building a cava binary on one machine to be used on another the features included, and hence the dependencies for the binary, are determined by the libraries installed on the development machine. Rather than create a build environment that only has access to the dependencies that are wanted for the final binary, this patch allows optional features to be disabled by configure options.

Strange issue...

When building for a Pi Zero on Raspbian with clang  (version 7.0.1-8+rpi3) , either building on the Pi Zero itslf or on a Pi 4 with `-march=armv6 -mfpu=vfp` and everything disabled except for input-alsa , the binary did not work correctly for fifo input and raw output, with levels rising quickly to maximum
```
pi@moode:~/cava $ cava -p conf3.txt 
open file /dev/stdout for writing raw ouput
9;10;255;79;72;41;32;16;16;17;
29;40;894;320;266;135;111;57;62;68;
61;109;1000;870;709;350;291;151;167;185;
155;285;1000;1000;1000;841;687;370;392;437;
369;700;1000;1000;1000;1000;1000;870;915;1000;
858;1000;1000;1000;1000;1000;1000;1000;1000;1000;
1000;1000;1000;1000;1000;1000;1000;1000;1000;1000;
1000;1000;1000;1000;1000;1000;1000;1000;1000;1000;
1000;1000;1000;1000;1000;1000;1000;1000;1000;1000;
1000;1000;1000;1000;1000;1000;1000;1000;1000;1000;
1000;1000;1000;1000;1000;1000;1000;1000;1000;1000;
1000;1000;1000;1000;1000;1000;1000;1000;1000;1000;
1000;1000;1000;1000;1000;1000;1000;1000;1000;1000;
1000;1000;1000;1000;1000;1000;1000;1000;1000;1000;
1000;1000;1000;1000;1000;1000;1000;1000;1000;1000;
1000;1000;1000;1000;1000;1000;1000;1000;1000;1000;
1000;1000;1000;1000;1000;1000;1000;1000;1000;1000;
1000;1000;1000;1000;1000;1000;1000;1000;1000;1000;
1000;1000;1000;1000;1000;1000;1000;1000;1000;1000;
1000;1000;1000;1000;1000;1000;1000;1000;1000;1000;
```
It worked fine when built with gcc

It seems to be related to some kind of interaction between clang, the alsa output feature, and the libraries "-ldl -ltinfo".

The issue occurs when running on the Pi Zero (binary built on the Pi Zero or on a Pi 4, clang version 7.0.1-8+rpi3). I didn't test on the Pi 4 itself. I tested on an Intel PC and the native clang (version 6.0.0-1ubuntu2) and didn't encounter the issue.

Here are some example configures that trigger the issue or not.

Triggers the issue (everything disabled, LDFLAGS used): 
```CC=clang CPPFLAGS="-march=armv6 -mfpu=vfp -W -Wall" LDFLAGS="-ldl -ltinfo" ./configure  --disable-input-alsa --disable-input-pulse --disable-input-portaudio --disable-input-sndio --disable-output-ncurses```

Doesn't trigger the issue (everything disabled, LDFLAGS not used)
```CC=clang CPPFLAGS="-march=armv6 -mfpu=vfp -W -Wall"  ./configure  --disable-input-alsa --disable-input-pulse --disable-input-portaudio --disable-input-sndio --disable-output-ncurses```

Doesn't trigger the issue (output-alsa enabled, LDFLAGS used): 
```CC=clang CPPFLAGS="-march=armv6 -mfpu=vfp -W -Wall" LDFLAGS="-ldl -ltinfo" ./configure --disable-input-pulse --disable-input-portaudio --disable-input-sndio --disable-output-ncurses```

Triggers the issue (output-alsa enabled, LDFLAGS not used):
```CC=clang CPPFLAGS="-march=armv6 -mfpu=vfp -W -Wall"  ./configure --disable-input-pulse --disable-input-portaudio --disable-input-sndio --disable-output-ncurses```

Doesn't trigger the issue (output-alsa enabled, LDFLAGS not used, built with gcc):
```CC=gcc CPPFLAGS="-march=armv6 -mfpu=vfp -W -Wall"  ./configure --disable-input-pulse --disable-input-portaudio --disable-input-sndio --disable-output-ncurses```


I have just cut and pasted the above commands and repeated the builds with the same results. I don't have an explanation for the behaviour.