### PR TITLE
Add hsheth2's PPA for Ubuntu 18+

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,11 @@ Michael Nguyen has added CAVA to his PPA, it can be installed with:
     sudo apt-get update
     sudo apt-get install cava
     
+For Ubuntu 18 or newer, you can use Harshal Sheth's PPA:
 
+    sudo add-apt-repository ppa:hsheth2/ppa
+    sudo apt-get update
+    sudo apt-get install cava
 
 All distro specific instalation sources might be out of date.
 


### PR DESCRIPTION
I was frustrated by #176, #227, and #281, so I uploaded cava to a PPA myself: https://launchpad.net/~hsheth2/+archive/ubuntu/ppa. 

Tested on Ubuntu 18.04 and Pop! OS 20.04. I also posted my PPA uploading code at https://github.com/hsheth2/cava-ppa.