### PR TITLE
Use format string to fix build

### DIFF
--- a/output/terminal_noncurses.c
+++ b/output/terminal_noncurses.c
@@ -175,11 +175,11 @@ int draw_terminal_noncurses(int tty, int h, int w, int bars, int bar_width, int 
                     }
 
                     if (current_char < 1)
-                        cx += snprintf(ttyline_buffer + cx, ttybuf_length - cx, ttyspacestring);
+                        cx += snprintf(ttyline_buffer + cx, ttybuf_length - cx, "%s", ttyspacestring);
                     else if (current_char > 7)
-                        cx += snprintf(ttyline_buffer + cx, ttybuf_length - cx, ttybarstring[0]);
+                        cx += snprintf(ttyline_buffer + cx, ttybuf_length - cx, "%s", ttybarstring[0]);
                     else
-                        cx += snprintf(ttyline_buffer + cx, ttybuf_length - cx,
+                        cx += snprintf(ttyline_buffer + cx, ttybuf_length - cx, "%s",
                                        ttybarstring[current_char]);
 
                     cx += snprintf(ttyline_buffer + cx, ttybuf_length - cx, "\033[%dC", bs);

--- a/output/terminal_noncurses.c
+++ b/output/terminal_noncurses.c
@@ -175,9 +175,11 @@ int draw_terminal_noncurses(int tty, int h, int w, int bars, int bar_width, int 
                     }
 
                     if (current_char < 1)
-                        cx += snprintf(ttyline_buffer + cx, ttybuf_length - cx, "%s", ttyspacestring);
+                        cx +=
+                            snprintf(ttyline_buffer + cx, ttybuf_length - cx, "%s", ttyspacestring);
                     else if (current_char > 7)
-                        cx += snprintf(ttyline_buffer + cx, ttybuf_length - cx, "%s", ttybarstring[0]);
+                        cx += snprintf(ttyline_buffer + cx, ttybuf_length - cx, "%s",
+                                       ttybarstring[0]);
                     else
                         cx += snprintf(ttyline_buffer + cx, ttybuf_length - cx, "%s",
                                        ttybarstring[current_char]);


### PR DESCRIPTION
When I build cava with strict compiler settings, I get this error:
```
output/terminal_noncurses.c: In function 'draw_terminal_noncurses':
output/terminal_noncurses.c:178:81: error: format not a string literal and no format arguments [-Werror=format-security]
                         cx += snprintf(ttyline_buffer + cx, ttybuf_length - cx, ttyspacestring);
                                                                                 ^~~~~~~~~~~~~~
output/terminal_noncurses.c:180:81: error: format not a string literal and no format arguments [-Werror=format-security]
                         cx += snprintf(ttyline_buffer + cx, ttybuf_length - cx, ttybarstring[0]);
                                                                                 ^~~~~~~~~~~~
output/terminal_noncurses.c:183:40: error: format not a string literal and no format arguments [-Werror=format-security]
                                        ttybarstring[current_char]);
                                        ^~~~~~~~~~~~
cc1: some warnings being treated as errors
```

This PR fixes those errors.