### PR TITLE
Don't open stdout as the "/dev/stdout" file

### DIFF
--- a/cava.c
+++ b/cava.c
@@ -551,25 +551,28 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
                         fptest = open(p.raw_target, O_RDONLY | O_NONBLOCK, 0644);
 
                         if (fptest == -1) {
-                            printf("could not open file %s for writing\n", p.raw_target);
+                            fprintf(stderr, "could not open file %s for writing\n", p.raw_target);
                             exit(1);
                         }
                     } else {
                         printf("creating fifo %s\n", p.raw_target);
                         if (mkfifo(p.raw_target, 0664) == -1) {
-                            printf("could not create fifo %s\n", p.raw_target);
+                            fprintf(stderr, "could not create fifo %s\n", p.raw_target);
                             exit(1);
                         }
                         // fifo needs to be open for reading in order to write to it
                         fptest = open(p.raw_target, O_RDONLY | O_NONBLOCK, 0644);
+                        fp = open(p.raw_target, O_WRONLY | O_NONBLOCK | O_CREAT, 0644);
                     }
+                } else {
+                    fp = fileno(stdout);
+                    fprintf(stderr, "Opening stdout\n");
                 }
-                fp = open(p.raw_target, O_WRONLY | O_NONBLOCK | O_CREAT, 0644);
                 if (fp == -1) {
-                    printf("could not open file %s for writing\n", p.raw_target);
+                    fprintf(stderr, "could not open file %s for writing\n", p.raw_target);
                     exit(1);
                 }
-                printf("open file %s for writing raw output\n", p.raw_target);
+                fprintf(stderr, "open file %s for writing raw output\n", p.raw_target);
 
                 // width must be hardcoded for raw output.
                 width = 256;


### PR DESCRIPTION
When exec-ing/forking cava from Node or Python, cava fails at opening the "/dev/stdout" file.

For instance, the script at https://github.com/karlstav/cava/issues/123#issuecomment-307891020 does not work on current 2021 Raspbian and leads to an error when opening /dev/stdout.

This patch just uses the already open stdout that is always available, and makes cava work in all situations I could test.