### PR TITLE
Fix SDL bar glitch

### DIFF
--- a/output/sdl_cava.c
+++ b/output/sdl_cava.c
@@ -80,9 +80,9 @@ int draw_sdl(int bars_count, int bar_width, int bar_spacing, int remainder, int 
             // clear bar from previous frame if lower
             if (bars[bar] < previous_frame[bar]) {
                 fillRect.x = bar * (bar_width + bar_spacing) + remainder;
-                fillRect.y = height - previous_frame[bar];
+                fillRect.y = 0;
                 fillRect.w = bar_width;
-                fillRect.h = previous_frame[bar];
+                fillRect.h = height;
                 SDL_SetRenderDrawColor(gRenderer, bg_color.R, bg_color.G, bg_color.B, 0xFF);
                 SDL_RenderFillRect(gRenderer, &fillRect);
             }


### PR DESCRIPTION
Removal of the total height between 2 rectangles of different height.

![Capture d’écran du 2022-02-05 14-54-00](https://user-images.githubusercontent.com/16121204/152645108-22ea148c-7597-4e3d-aa78-0d37a7600bc0.png)

