### PR TITLE
Remove note about bundled iniparser from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,6 @@ Only FFTW and the other build tools are actually required for CAVA to compile, b
 
 For better a better visual experience ncurses is also recomended.
 
-Iniparser is also required, but if it is not already installed, a bundled version will be used.
-
 All the requirements can be installed easily in all major distros:
 
 Debian Buster or higher/Ubuntu 18.04 or higher :


### PR DESCRIPTION
After https://github.com/karlstav/cava/commit/97a811060d2e35c686269eab2b18c8b0009de71f this isn't true anymore is it?