### PR TITLE
Add new raw binary output for "noritake" VFD bitmap format

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,7 @@ ACLOCAL_AMFLAGS = -I m4
 
 bin_PROGRAMS = cava
 cava_SOURCES = cava.c config.c input/common.c input/fifo.c input/shmem.c \
-               output/terminal_noncurses.c output/raw.c
+               output/terminal_noncurses.c output/raw.c output/noritake.c
 cava_CPPFLAGS = -DPACKAGE=\"$(PACKAGE)\" -DVERSION=\"$(VERSION)\" \
            -D_POSIX_SOURCE -D _POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE_EXTENDED \
 	   -DFONTDIR=\"@FONT_DIR@\"

--- a/config.c
+++ b/config.c
@@ -197,15 +197,19 @@ bool validate_config(struct config_params *p, struct error_s *error) {
         p->output = OUTPUT_NONCURSES;
         p->bgcol = 0;
     }
+    if (strcmp(outputMethod, "noritake") == 0) {
+        p->output = OUTPUT_NORITAKE;
+        p->raw_format = FORMAT_NTK3000; // only format supported now
+    }
     if (strcmp(outputMethod, "raw") == 0) { // raw:
         p->output = OUTPUT_RAW;
         p->bar_spacing = 0;
         p->bar_width = 1;
 
         // checking data format
-        p->is_bin = -1;
+        p->raw_format = -1;
         if (strcmp(p->data_format, "binary") == 0) {
-            p->is_bin = 1;
+            p->raw_format = FORMAT_BINARY;
             // checking bit format:
             if (p->bit_format != 8 && p->bit_format != 16) {
                 write_errorf(
@@ -215,7 +219,7 @@ bool validate_config(struct config_params *p, struct error_s *error) {
                 return false;
             }
         } else if (strcmp(p->data_format, "ascii") == 0) {
-            p->is_bin = 0;
+            p->raw_format = FORMAT_ASCII;
             if (p->ascii_range < 1) {
                 write_errorf(error, "ascii max value must be a positive integer\n");
                 return false;
@@ -458,6 +462,7 @@ bool load_config(char configPath[PATH_MAX], struct config_params *p, bool colors
     p->fixedbars = iniparser_getint(ini, "general:bars", 0);
     p->bar_width = iniparser_getint(ini, "general:bar_width", 2);
     p->bar_spacing = iniparser_getint(ini, "general:bar_spacing", 1);
+    p->bar_height = iniparser_getint(ini, "general:bar_height", 32);
     p->framerate = iniparser_getint(ini, "general:framerate", 60);
     p->sens = iniparser_getint(ini, "general:sensitivity", 100);
     p->autosens = iniparser_getint(ini, "general:autosens", 1);

--- a/config.h
+++ b/config.h
@@ -48,8 +48,11 @@ enum output_method {
     OUTPUT_NONCURSES,
     OUTPUT_RAW,
     OUTPUT_SDL,
+    OUTPUT_NORITAKE,
     OUTPUT_NOT_SUPORTED
 };
+
+enum data_format { FORMAT_ASCII = 0, FORMAT_BINARY = 1, FORMAT_NTK3000 = 2 };
 
 enum xaxis_scale { NONE, FREQUENCY, NOTE };
 
@@ -63,10 +66,10 @@ struct config_params {
     enum input_method input;
     enum output_method output;
     enum xaxis_scale xaxis;
-    int userEQ_keys, userEQ_enabled, col, bgcol, autobars, stereo, is_bin, ascii_range, bit_format,
-        gradient, gradient_count, fixedbars, framerate, bar_width, bar_spacing, autosens, overshoot,
-        waves, fifoSample, fifoSampleBits, sleep_timer, sdl_width, sdl_height, sdl_x, sdl_y,
-        draw_and_quit, zero_test, non_zero_test, reverse;
+    int userEQ_keys, userEQ_enabled, col, bgcol, autobars, stereo, raw_format, ascii_range,
+        bit_format, gradient, gradient_count, fixedbars, framerate, bar_width, bar_spacing,
+        bar_height, autosens, overshoot, waves, fifoSample, fifoSampleBits, sleep_timer, sdl_width,
+        sdl_height, sdl_x, sdl_y, draw_and_quit, zero_test, non_zero_test, reverse;
 };
 
 struct error_s {

--- a/example_files/config
+++ b/example_files/config
@@ -24,6 +24,8 @@
 ; bars = 0
 ; bar_width = 2
 ; bar_spacing = 1
+# bar_height is only used for output in "noritake" format
+; bar_height = 32
 
 # For SDL width and space between bars is in pixels, defaults are:
 ; bar_width = 20
@@ -77,13 +79,16 @@
 
 [output]
 
-# Output method. Can be 'ncurses', 'noncurses', 'raw' or 'sdl'.
+# Output method. Can be 'ncurses', 'noncurses', 'raw', 'noritake' or 'sdl'.
 # 'noncurses' uses a custom framebuffer technique and prints only changes
 # from frame to frame in the terminal. 'ncurses' is default if supported.
 #
 # 'raw' is an 8 or 16 bit (configurable via the 'bit_format' option) data
 # stream of the bar heights that can be used to send to other applications.
 # 'raw' defaults to 200 bars, which can be adjusted in the 'bars' option above.
+#
+# 'noritake' outputs a bitmap in the format expected by a Noritake VFD display
+#  in graphic mode. It only support the 3000 series graphical VFDs for now.
 #
 # 'sdl' uses the Simple DirectMedia Layer to render in a graphical context.
 ; method = ncurses

--- a/output/noritake.c
+++ b/output/noritake.c
@@ -1,0 +1,38 @@
+#include "../config.h"
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <unistd.h>
+
+int16_t buf_16;
+int8_t buf_8;
+int8_t val1;
+uint64_t bits;
+int8_t j;
+int8_t k;
+
+int print_ntk_out(int bars_count, int fd, int packing, int bit_format, int bar_width,
+                  int bar_spacing, int bar_height, int const f[]) {
+    if (packing == FORMAT_NTK3000) {
+        // Custom Noritake VFD bitmap for 3000-series
+        for (int i = 0; i < bars_count; i++) {
+            int f_limited = f[i];
+            if (f_limited > (pow(2, bit_format) - 1))
+                f_limited = pow(2, bit_format) - 1;
+
+            val1 = f_limited >> (bar_height / 8 - 1); // Will not work above 32 for now
+            bits = pow(2, val1) - 1;
+            for (k = 0; k < bar_width; k++) {
+                for (j = 0; j < bar_height / 8; j++) {
+                    buf_8 = bits >> (8 * (bar_height / 8 - 1 - j)) & 0xff;
+                    write(fd, &buf_8, sizeof(int8_t));
+                }
+            }
+            buf_8 = 0;
+            for (j = 0; j < bar_height / 8 * bar_spacing; j++) {
+                write(fd, &buf_8, sizeof(int8_t));
+            }
+        }
+    }
+    return 0;
+}

--- a/output/noritake.h
+++ b/output/noritake.h
@@ -1,0 +1,2 @@
+int print_ntk_out(int bars_count, int fd, int is_binary, int bit_format, int bar_width,
+                  int bar_spacing, int bar_height, int const f[]);


### PR DESCRIPTION
This makes it possible to use the output of cava on Noritake VFD displays directly with no additional processing.

It can  achieve framerates of 70+ fps on 3900 series displays on a Raspberry Pi with no particular effort.

Noritake bitmap raw output bar height is configurable with height up to 32 pixels.

Issue #439 