### PR TITLE
Implement different orientations of output for SDL

### DIFF
--- a/cava.c
+++ b/cava.c
@@ -552,15 +552,17 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
             }
 
             // checks if there is stil extra room, will use this to center
-            remainder = (dimension_bar - number_of_bars * p.bar_width - number_of_bars * p.bar_spacing +
-                         p.bar_spacing) /
+            remainder = (dimension_bar - number_of_bars * p.bar_width -
+                         number_of_bars * p.bar_spacing + p.bar_spacing) /
                         2;
             if (remainder < 0)
                 remainder = 0;
 
 #ifndef NDEBUG
-            debug("height: %d width: %d dimension_bar: %d dimension_value: %d bars:%d bar width: %d remainder: %d\n", height, width,
-                  dimension_bar, dimension_value, number_of_bars, p.bar_width, remainder);
+            debug("height: %d width: %d dimension_bar: %d dimension_value: %d bars:%d bar width: "
+                  "%d remainder: %d\n",
+                  height, width, dimension_bar, dimension_value, number_of_bars, p.bar_width,
+                  remainder);
 #endif
 
             double userEQ_keys_to_bars_ratio;
@@ -913,8 +915,9 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
 #endif
 #ifdef SDL
                 case OUTPUT_SDL:
-                    rc = draw_sdl(number_of_bars, p.bar_width, p.bar_spacing, remainder, dimension_value,
-                                  bars, previous_frame, frame_time_msec, p.orientation);
+                    rc = draw_sdl(number_of_bars, p.bar_width, p.bar_spacing, remainder,
+                                  dimension_value, bars, previous_frame, frame_time_msec,
+                                  p.orientation);
                     break;
 #endif
                 case OUTPUT_NONCURSES:

--- a/cava.c
+++ b/cava.c
@@ -412,6 +412,7 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
         double *cava_out;
 
         int height, lines, width, remainder, fp;
+        int dimension_bar, dimension_value;
 
 #ifdef SDL
         // output: start sdl mode
@@ -515,11 +516,19 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
                     p.autobars = 1;
             }
 
+            if (p.orientation == ORIENT_LEFT || p.orientation == ORIENT_RIGHT) {
+                dimension_bar = height;
+                dimension_value = width;
+            } else {
+                dimension_bar = width;
+                dimension_value = height;
+            }
+
             // getting numbers of bars
             int number_of_bars = p.fixedbars;
 
             if (p.autobars == 1)
-                number_of_bars = (width + p.bar_spacing) / (p.bar_width + p.bar_spacing);
+                number_of_bars = (dimension_bar + p.bar_spacing) / (p.bar_width + p.bar_spacing);
 
             if (number_of_bars <= 1) {
                 number_of_bars = 1; // must have at least 1 bars
@@ -543,15 +552,15 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
             }
 
             // checks if there is stil extra room, will use this to center
-            remainder = (width - number_of_bars * p.bar_width - number_of_bars * p.bar_spacing +
+            remainder = (dimension_bar - number_of_bars * p.bar_width - number_of_bars * p.bar_spacing +
                          p.bar_spacing) /
                         2;
             if (remainder < 0)
                 remainder = 0;
 
 #ifndef NDEBUG
-            debug("height: %d width: %d bars:%d bar width: %d remainder: %d\n", height, width,
-                  number_of_bars, p.bar_width, remainder);
+            debug("height: %d width: %d dimension_bar: %d dimension_value: %d bars:%d bar width: %d remainder: %d\n", height, width,
+                  dimension_bar, dimension_value, number_of_bars, p.bar_width, remainder);
 #endif
 
             double userEQ_keys_to_bars_ratio;
@@ -771,7 +780,7 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
 
                 for (uint32_t n = 0; n < (number_of_bars / output_channels) * audio.channels; n++) {
                     if (p.autosens)
-                        cava_out[n] *= height;
+                        cava_out[n] *= dimension_value;
                     else
                         cava_out[n] *= p.sens;
                 }
@@ -904,8 +913,8 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
 #endif
 #ifdef SDL
                 case OUTPUT_SDL:
-                    rc = draw_sdl(number_of_bars, p.bar_width, p.bar_spacing, remainder, height,
-                                  bars, previous_frame, frame_time_msec);
+                    rc = draw_sdl(number_of_bars, p.bar_width, p.bar_spacing, remainder, dimension_value,
+                                  bars, previous_frame, frame_time_msec, p.orientation);
                     break;
 #endif
                 case OUTPUT_NONCURSES:

--- a/config.c
+++ b/config.c
@@ -26,7 +26,7 @@ enum input_method default_methods[] = {
     INPUT_PULSE,
 };
 
-char *outputMethod, *channels, *xaxisScale, *monoOption;
+char *outputMethod, *orientation, *channels, *xaxisScale, *monoOption;
 
 const char *input_method_names[] = {
     "fifo", "portaudio", "alsa", "pulse", "sndio", "shmem",
@@ -236,6 +236,19 @@ bool validate_config(struct config_params *p, struct error_s *error) {
         write_errorf(error, "output method %s is not supported, supported methods are: %s\n",
                      outputMethod, supportedOutput);
         return false;
+    }
+
+    p->orientation = ORIENT_BOTTOM;
+    if (p->output == OUTPUT_SDL) {
+        if (strcmp(orientation, "top") == 0) {
+            p->orientation = ORIENT_TOP;
+        }
+        if (strcmp(orientation, "left") == 0) {
+            p->orientation = ORIENT_LEFT;
+        }
+        if (strcmp(orientation, "right") == 0) {
+            p->orientation = ORIENT_RIGHT;
+        }
     }
 
     p->xaxis = NONE;
@@ -452,6 +465,7 @@ bool load_config(char configPath[PATH_MAX], struct config_params *p, bool colors
     outputMethod = (char *)iniparser_getstring(ini, "output:method", "noncurses");
 #endif
 
+    orientation = (char *)iniparser_getstring(ini, "output:orientation", "bottom");
     xaxisScale = (char *)iniparser_getstring(ini, "output:xaxis", "none");
     p->monstercat = 1.5 * iniparser_getdouble(ini, "smoothing:monstercat", 0);
     p->waves = iniparser_getint(ini, "smoothing:waves", 0);

--- a/config.h
+++ b/config.h
@@ -57,6 +57,8 @@ enum data_format { FORMAT_ASCII = 0, FORMAT_BINARY = 1, FORMAT_NTK3000 = 2 };
 
 enum xaxis_scale { NONE, FREQUENCY, NOTE };
 
+enum orientation { ORIENT_BOTTOM, ORIENT_TOP, ORIENT_LEFT, ORIENT_RIGHT};
+
 struct config_params {
     char *color, *bcolor, *raw_target, *audio_source,
         /**gradient_color_1, *gradient_color_2,*/ **gradient_colors, *data_format;
@@ -68,6 +70,7 @@ struct config_params {
     enum output_method output;
     enum xaxis_scale xaxis;
     enum mono_option mono_opt;
+    enum orientation orientation;
     int userEQ_keys, userEQ_enabled, col, bgcol, autobars, stereo, raw_format, ascii_range,
         bit_format, gradient, gradient_count, fixedbars, framerate, bar_width, bar_spacing,
         bar_height, autosens, overshoot, waves, fifoSample, fifoSampleBits, sleep_timer, sdl_width,

--- a/config.h
+++ b/config.h
@@ -57,7 +57,7 @@ enum data_format { FORMAT_ASCII = 0, FORMAT_BINARY = 1, FORMAT_NTK3000 = 2 };
 
 enum xaxis_scale { NONE, FREQUENCY, NOTE };
 
-enum orientation { ORIENT_BOTTOM, ORIENT_TOP, ORIENT_LEFT, ORIENT_RIGHT};
+enum orientation { ORIENT_BOTTOM, ORIENT_TOP, ORIENT_LEFT, ORIENT_RIGHT };
 
 struct config_params {
     char *color, *bcolor, *raw_target, *audio_source,

--- a/example_files/config
+++ b/example_files/config
@@ -93,6 +93,10 @@
 # 'sdl' uses the Simple DirectMedia Layer to render in a graphical context.
 ; method = ncurses
 
+# Orientation of the visualization. Can be 'bottom', 'top', 'left' or 'right'.
+# Default is 'bottom'. Other orientations are only supported out sdl output.
+; orientation = bottom
+
 # Visual channels. Can be 'stereo' or 'mono'.
 # 'stereo' mirrors both channels with low frequencies in center.
 # 'mono' outputs left to right lowest to highest frequencies.

--- a/example_files/config
+++ b/example_files/config
@@ -94,7 +94,7 @@
 ; method = ncurses
 
 # Orientation of the visualization. Can be 'bottom', 'top', 'left' or 'right'.
-# Default is 'bottom'. Other orientations are only supported out sdl output.
+# Default is 'bottom'. Other orientations are only supported on sdl output.
 ; orientation = bottom
 
 # Visual channels. Can be 'stereo' or 'mono'.

--- a/output/sdl_cava.c
+++ b/output/sdl_cava.c
@@ -1,6 +1,6 @@
-#include "output/sdl_cava.h"
-
 #include <SDL2/SDL.h>
+
+#include "output/sdl_cava.h"
 
 #include <stdbool.h>
 #include <stdlib.h>

--- a/output/sdl_cava.c
+++ b/output/sdl_cava.c
@@ -80,31 +80,31 @@ int draw_sdl(int bars_count, int bar_width, int bar_spacing, int remainder, int 
         SDL_SetRenderDrawColor(gRenderer, bg_color.R, bg_color.G, bg_color.B, 0xFF);
         SDL_RenderClear(gRenderer);
         for (int bar = 0; bar < bars_count; bar++) {
-            switch(orientation) {
-                case ORIENT_LEFT:
-                    fillRect.x = 0;
-                    fillRect.y = bar * (bar_width + bar_spacing) + remainder;
-                    fillRect.w = bars[bar];
-                    fillRect.h = bar_width;
-                    break;
-                case ORIENT_RIGHT:
-                    fillRect.x = height - bars[bar];
-                    fillRect.y = bar * (bar_width + bar_spacing) + remainder;
-                    fillRect.w = bars[bar];
-                    fillRect.h = bar_width;
-                    break;
-                case ORIENT_TOP:
-                    fillRect.x = bar * (bar_width + bar_spacing) + remainder;
-                    fillRect.y = 0;
-                    fillRect.w = bar_width;
-                    fillRect.h = bars[bar];
-                    break;
-                default:
-                    fillRect.x = bar * (bar_width + bar_spacing) + remainder;
-                    fillRect.y = height - bars[bar];
-                    fillRect.w = bar_width;
-                    fillRect.h = bars[bar];
-                    break;
+            switch (orientation) {
+            case ORIENT_LEFT:
+                fillRect.x = 0;
+                fillRect.y = bar * (bar_width + bar_spacing) + remainder;
+                fillRect.w = bars[bar];
+                fillRect.h = bar_width;
+                break;
+            case ORIENT_RIGHT:
+                fillRect.x = height - bars[bar];
+                fillRect.y = bar * (bar_width + bar_spacing) + remainder;
+                fillRect.w = bars[bar];
+                fillRect.h = bar_width;
+                break;
+            case ORIENT_TOP:
+                fillRect.x = bar * (bar_width + bar_spacing) + remainder;
+                fillRect.y = 0;
+                fillRect.w = bar_width;
+                fillRect.h = bars[bar];
+                break;
+            default:
+                fillRect.x = bar * (bar_width + bar_spacing) + remainder;
+                fillRect.y = height - bars[bar];
+                fillRect.w = bar_width;
+                fillRect.h = bars[bar];
+                break;
             }
 
             SDL_SetRenderDrawColor(gRenderer, fg_color.R, fg_color.G, fg_color.B, 0xFF);

--- a/output/sdl_cava.c
+++ b/output/sdl_cava.c
@@ -63,7 +63,7 @@ void init_sdl_surface(int *w, int *h, char *const fg_color_string, char *const b
 }
 
 int draw_sdl(int bars_count, int bar_width, int bar_spacing, int remainder, int height,
-             const int bars[], int previous_frame[], int frame_time) {
+             const int bars[], int previous_frame[], int frame_time, enum orientation orientation) {
 
     bool update = false;
     int rc = 0;
@@ -80,10 +80,33 @@ int draw_sdl(int bars_count, int bar_width, int bar_spacing, int remainder, int 
         SDL_SetRenderDrawColor(gRenderer, bg_color.R, bg_color.G, bg_color.B, 0xFF);
         SDL_RenderClear(gRenderer);
         for (int bar = 0; bar < bars_count; bar++) {
-            fillRect.x = bar * (bar_width + bar_spacing) + remainder;
-            fillRect.y = height - bars[bar];
-            fillRect.w = bar_width;
-            fillRect.h = bars[bar];
+            switch(orientation) {
+                case ORIENT_LEFT:
+                    fillRect.x = 0;
+                    fillRect.y = bar * (bar_width + bar_spacing) + remainder;
+                    fillRect.w = bars[bar];
+                    fillRect.h = bar_width;
+                    break;
+                case ORIENT_RIGHT:
+                    fillRect.x = height - bars[bar];
+                    fillRect.y = bar * (bar_width + bar_spacing) + remainder;
+                    fillRect.w = bars[bar];
+                    fillRect.h = bar_width;
+                    break;
+                case ORIENT_TOP:
+                    fillRect.x = bar * (bar_width + bar_spacing) + remainder;
+                    fillRect.y = 0;
+                    fillRect.w = bar_width;
+                    fillRect.h = bars[bar];
+                    break;
+                default:
+                    fillRect.x = bar * (bar_width + bar_spacing) + remainder;
+                    fillRect.y = height - bars[bar];
+                    fillRect.w = bar_width;
+                    fillRect.h = bars[bar];
+                    break;
+            }
+
             SDL_SetRenderDrawColor(gRenderer, fg_color.R, fg_color.G, fg_color.B, 0xFF);
             SDL_RenderFillRect(gRenderer, &fillRect);
         }

--- a/output/sdl_cava.h
+++ b/output/sdl_cava.h
@@ -1,6 +1,8 @@
+#include "../config.h"
+
 void init_sdl_window(int width, int height, int x, int y);
 void init_sdl_surface(int *width, int *height, char *const fg_color_string,
                       char *const bg_color_string);
 int draw_sdl(int bars_count, int bar_width, int bar_spacing, int remainder, int height,
-             const int bars[], int previous_frame[], int frame_timer);
+             const int bars[], int previous_frame[], int frame_timer, enum orientation orientation);
 void cleanup_sdl(void);


### PR DESCRIPTION
Currently cava only supports bars that are aligned to the bottom of the window and point upwards. This commit allows them to be aligned to any edge of the window.

For now it is only implemented this for SDL, because it was the simplest, but I may also do it for ncurses output.

Issue link: https://github.com/karlstav/cava/issues/471