### PR TITLE
Remove unnecessary variables from cava_plan

### DIFF
--- a/cavacore.c
+++ b/cavacore.c
@@ -89,8 +89,6 @@ struct cava_plan *cava_init(int number_of_bars, unsigned int rate, int channels,
     p->average_max = 0;
     p->noise_reduction = noise_reduction;
 
-    p->g = log10((float)p->height) * 0.05;
-
     p->FFTbassbufferSize = treble_buffer_size * 8;
     p->FFTmidbufferSize = treble_buffer_size * 4;
     p->FFTtreblebufferSize = treble_buffer_size;

--- a/cavacore.h
+++ b/cavacore.h
@@ -40,7 +40,6 @@ struct cava_plan {
     int rate;
     int bass_cut_off_bar;
     int treble_cut_off_bar;
-    int height;
     int sens_init;
     int autosens;
     int frame_skip;

--- a/cavacore.h
+++ b/cavacore.h
@@ -48,7 +48,6 @@ struct cava_plan {
     char error_message[1024];
 
     double sens;
-    double g;
     double framerate;
     double average_max;
     double noise_reduction;


### PR DESCRIPTION
These 2 aren't used anywhere, when running cava through valgrind they trigger this:
```
==1492574== Conditional jump or move depends on uninitialised value(s)
==1492574==    at 0x62622AC: log10 (w_log10_compat.c:30)
==1492574==    by 0x485B1F9: cava_init (in /home/jacek/Sources/waybar/build/subprojects/cava-0.8.3/libcava.so)
........
```
Found this out with waybar's cava module, tested both with waybar and cava standalone, doesn't trigger it anymore