### PR TITLE
added missing fedora dependency needed for compilation - iniparser-devel

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ openSUSE:
 
 Fedora:
 
-    dnf install alsa-lib-devel ncurses-devel fftw3-devel pulseaudio-libs-devel libtool autoconf-archive
+    dnf install alsa-lib-devel ncurses-devel fftw3-devel pulseaudio-libs-devel libtool autoconf-archive iniparser-devel
 
     
 macOS:


### PR DESCRIPTION
The iniparser-devel wasn't included in the fedora dependency install command, which as a result returned the following error whenever building cava:

![image](https://github.com/karlstav/cava/assets/83690012/eab9aa77-d5b4-42aa-a516-1b7a0b218e8a)

Which was fixed after adding ``iniparser-devel`` to the install command in the readme, (the iniparser package didn't work, devel is needed)