### PR TITLE
OSS input backend and general improved FreeBSD support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,7 @@ cava_SOURCES = cava.c cavacore.c config.c input/common.c input/fifo.c input/shme
                output/terminal_noncurses.c output/raw.c output/noritake.c
 cava_CPPFLAGS = -DPACKAGE=\"$(PACKAGE)\" -DVERSION=\"$(VERSION)\" \
            -D_POSIX_SOURCE -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE_EXTENDED \
-	   -DFONTDIR=\"@FONT_DIR@\"
+	   -DFONTDIR=\"@FONT_DIR@\" -DFONTFILE=\"@FONT_FILE@\"
 cava_CFLAGS = -std=c99 -Wall -Wextra -Wno-unused-result -Wno-unknown-warning-option -Wno-maybe-uninitialized -Wno-vla-parameter
 
 if OSX
@@ -16,7 +16,17 @@ if OSX
 else
     cava_LDADD = -lrt
     cava_font_dir = @FONT_DIR@
-    cava_font__DATA = cava.psf
+    cava_font__DATA = @FONT_FILE@
+endif
+
+if FREEBSD
+if CAVAFONT
+    CLEANFILES = cava.bdf cava.fnt
+
+cava.fnt: ${srcdir}/cava.psf
+	${PSF2BDF} --fontname="-gnu-cava-medium-r-normal--16-160-75-75-c-80-iso10646-1" ${srcdir}/cava.psf cava.bdf
+	${VTFONTCVT} -o cava.fnt cava.bdf
+endif
 endif
 
 if ALSA
@@ -37,6 +47,10 @@ endif
 
 if SNDIO
     cava_SOURCES += input/sndio.c
+endif
+
+if OSS
+    cava_SOURCES += input/oss.c
 endif
 
 if NCURSES

--- a/config.c
+++ b/config.c
@@ -45,19 +45,20 @@ const char *default_shader_name[NUMBER_OF_SHADERS] = {"northern_lights.frag", "p
 double smoothDef[5] = {1, 1, 1, 1, 1};
 
 enum input_method default_methods[] = {
-    INPUT_FIFO, INPUT_PORTAUDIO, INPUT_ALSA, INPUT_PULSE, INPUT_PIPEWIRE, INPUT_WINSCAP,
+    INPUT_FIFO,     INPUT_PORTAUDIO, INPUT_ALSA,  INPUT_PULSE,
+    INPUT_PIPEWIRE, INPUT_WINSCAP,   INPUT_SNDIO, INPUT_OSS,
 };
 
 char *outputMethod, *orientation, *channels, *xaxisScale, *monoOption, *fragmentShader,
     *vertexShader;
 
 const char *input_method_names[] = {
-    "fifo", "portaudio", "pipewire", "alsa", "pulse", "sndio", "shmem", "winscap",
+    "fifo", "portaudio", "pipewire", "alsa", "pulse", "sndio", "oss", "shmem", "winscap",
 };
 
 const bool has_input_method[] = {
     HAS_FIFO, /** Always have at least FIFO and shmem input. */
-    HAS_PORTAUDIO, HAS_PIPEWIRE, HAS_ALSA, HAS_PULSE, HAS_SNDIO, HAS_SHMEM, HAS_WINSCAP,
+    HAS_PORTAUDIO, HAS_PIPEWIRE, HAS_ALSA, HAS_PULSE, HAS_SNDIO, HAS_OSS, HAS_SHMEM, HAS_WINSCAP,
 };
 
 enum input_method input_method_by_name(const char *str) {
@@ -711,6 +712,11 @@ bool load_config(char configPath[PATH_MAX], struct config_params *p, bool colors
 #ifdef SNDIO
     case INPUT_SNDIO:
         p->audio_source = strdup(iniparser_getstring(ini, "input:source", SIO_DEVANY));
+        break;
+#endif
+#ifdef OSS
+    case INPUT_OSS:
+        p->audio_source = strdup(iniparser_getstring(ini, "input:source", "/dev/dsp"));
         break;
 #endif
     case INPUT_SHMEM:

--- a/config.h
+++ b/config.h
@@ -37,6 +37,12 @@
 #define HAS_SNDIO false
 #endif
 
+#ifdef OSS
+#define HAS_OSS true
+#else
+#define HAS_OSS false
+#endif
+
 #ifdef _MSC_VER
 #define HAS_WINSCAP true
 #define SDL true
@@ -59,6 +65,7 @@ enum input_method {
     INPUT_ALSA,
     INPUT_PULSE,
     INPUT_SNDIO,
+    INPUT_OSS,
     INPUT_SHMEM,
     INPUT_WINSCAP,
     INPUT_MAX,

--- a/configure.ac
+++ b/configure.ac
@@ -231,13 +231,17 @@ AC_ARG_ENABLE([input_oss],
 )
 
 AS_IF([test "x$enable_input_oss" != "xno"], [
-  AC_CHECK_HEADERS(sys/soundcard.h, have_oss=yes, have_oss=no)
-  if [[ $have_oss = "yes" ]] ; then
-    CPPFLAGS="$CPPFLAGS -DOSS -D__BSD_VISIBLE"
-  fi
+  have_oss=no
 
-  if [[ $have_oss = "no" ]] ; then
-    AC_MSG_NOTICE([WARNING: No oss dev files found building without oss support])
+  if [[ $build_freebsd = "yes" ]] ; then
+    AC_CHECK_HEADERS(sys/soundcard.h, have_oss=yes, have_oss=no)
+    if [[ $have_oss = "yes" ]] ; then
+      CPPFLAGS="$CPPFLAGS -DOSS -D__BSD_VISIBLE"
+    fi
+
+    if [[ $have_oss = "no" ]] ; then
+      AC_MSG_NOTICE([WARNING: No oss dev files found building without oss support])
+    fi
   fi],
   [have_oss=no]
 )

--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,39 @@ AC_PROG_CC_STDC
 AM_PROG_LIBTOOL
 
 
+AC_CANONICAL_HOST
+
+build_linux=no
+build_windows=no
+build_mac=no
+build_freebsd=no
+
+AC_MSG_NOTICE([Checking OS])
+# Detect the target system
+case "${host_os}" in
+    linux*)
+        AC_MSG_NOTICE([Linux detected])
+        build_linux=yes
+        ;;
+    darwin*)
+        AC_MSG_NOTICE([OSX detected])
+        build_mac=yes
+        ;;
+    freebsd*)
+        AC_MSG_NOTICE([FreeBSD detected])
+        build_freebsd=yes
+        ;;
+    *)
+        AC_MSG_ERROR(["OS $host_os is not supported"])
+        ;;
+esac
+
+# Pass the conditionals to automake
+AM_CONDITIONAL([LINUX], [test "$build_linux" = "yes"])
+AM_CONDITIONAL([OSX], [test "$build_mac" = "yes"])
+AM_CONDITIONAL([FREEBSD], [test "$build_freebsd" = "yes"])
+
+
 dnl ############################
 dnl checking if debug is enabled
 dnl ############################
@@ -184,10 +217,32 @@ AS_IF([test "x$enable_input_sndio" != "xno"], [
   if [[ $have_sndio = "no" ]] ; then
     AC_MSG_NOTICE([WARNING: No sndio dev files found building without sndio support])
   fi],
-  [have_portaudio=no]
+  [have_sndio=no]
 )
 
 AM_CONDITIONAL([SNDIO], [test "x$have_sndio" = "xyes"])
+
+dnl ######################
+dnl checking for oss dev
+dnl ######################
+AC_ARG_ENABLE([input_oss],
+  AS_HELP_STRING([--disable-input-oss],
+    [do not include support for input from oss])
+)
+
+AS_IF([test "x$enable_input_oss" != "xno"], [
+  AC_CHECK_HEADERS(sys/soundcard.h, have_oss=yes, have_oss=no)
+  if [[ $have_oss = "yes" ]] ; then
+    CPPFLAGS="$CPPFLAGS -DOSS -D__BSD_VISIBLE"
+  fi
+
+  if [[ $have_oss = "no" ]] ; then
+    AC_MSG_NOTICE([WARNING: No oss dev files found building without oss support])
+  fi],
+  [have_oss=no]
+)
+
+AM_CONDITIONAL([OSS], [test "x$have_oss" = "xyes"])
 
 dnl ######################
 dnl checking for math lib
@@ -304,6 +359,39 @@ AM_CONDITIONAL([NCURSES], [test "x$have_ncurses" = "xyes"])
 
 
 dnl ######################
+dnl checking for cava font
+dnl ######################
+AC_ARG_ENABLE([cava_font],
+  AS_HELP_STRING([--disable-cava-font],
+    [do not include support for the console cava font])
+)
+
+AS_IF([test "x$enable_cava_font" != "xno"], [
+  have_cava_font=yes
+
+  if [[ $build_freebsd = "yes" ]] ; then
+    AC_PATH_PROG(VTFONTCVT, vtfontcvt)
+    if [[ -z "$VTFONTCVT" ]] ; then
+      AC_MSG_NOTICE([WARNING: vtfontcvt not found])
+      have_cava_font=no
+    fi
+    AC_PATH_PROG(PSF2BDF, psf2bdf)
+    if [[ -z "$PSF2BDF" ]] ; then
+      AC_MSG_NOTICE([WARNING: psf2bdf not found])
+      have_cava_font=no
+    fi
+    if [[ $have_cava_font = "no" ]] ; then
+      AC_MSG_NOTICE([WARNING: Font conversion tool missing. Building without cava font supported!])
+    fi
+  fi],
+  [have_cava_font=no]
+)
+
+AS_IF([test "x$have_cava_font" = "xyes"], [CPPFLAGS="$CPPFLAGS -DCAVAFONT"], [])
+AM_CONDITIONAL([CAVAFONT], [test "x$have_cava_font" = "xyes"])
+
+
+dnl ######################
 dnl checking for iniparser
 dnl ######################
 
@@ -326,41 +414,25 @@ AC_CHECK_LIB(iniparser,iniparser_load, have_iniparser=yes, have_iniparser=no)
 dnl ############################
 dnl Set font directory
 dnl ############################
-DEFAULT_FONT_DIR="${datarootdir}/consolefonts"
 AC_ARG_VAR(FONT_DIR, [Directory where the font will be installed.])
+AC_SUBST([FONT_FILE])
+
+AS_IF([test "x$have_cava_font" = "xyes"], [
+  if [[ "$build_freebsd" = "yes" ]] ; then
+    DEFAULT_FONT_DIR="${datarootdir}/cava"
+    FONT_FILE="cava.fnt"
+  else
+    DEFAULT_FONT_DIR="${datarootdir}/consolefonts"
+    FONT_FILE="cava.psf"
+  fi], [
+    DEFAULT_FONT_DIR=
+    FONT_FILE=]
+)
+
 if test -z "$FONT_DIR" ; then
   FONT_DIR="$DEFAULT_FONT_DIR"
 fi
 
-AC_CANONICAL_HOST
-
-build_linux=no
-build_windows=no
-build_mac=no
-
-AC_MSG_NOTICE([Checking OS])
-# Detect the target system
-case "${host_os}" in
-    linux*)
-        AC_MSG_NOTICE([Linux detected])
-        build_linux=yes
-        ;;
-    darwin*)
-        AC_MSG_NOTICE([OSX detected])
-        build_mac=yes
-        ;;
-    freebsd*)
-        AC_MSG_NOTICE([FreeBSD detected])
-        build_linux=yes
-        ;;
-    *)
-        AC_MSG_ERROR(["OS $host_os is not supported"])
-        ;;
-esac
-
-# Pass the conditionals to automake
-AM_CONDITIONAL([LINUX], [test "$build_linux" = "yes"])
-AM_CONDITIONAL([OSX], [test "$build_mac" = "yes"])
 
 
 AC_CONFIG_FILES([Makefile])

--- a/example_files/config
+++ b/example_files/config
@@ -52,8 +52,8 @@
 
 [input]
 
-# Audio capturing method. Possible methods are: 'pulse', 'alsa', 'fifo', 'sndio' or 'shmem'
-# Defaults to 'pulse', 'pipewire', 'alsa' or 'fifo', in that order, dependent on what support cava was built with.
+# Audio capturing method. Possible methods are: 'fifo', 'portaudio', 'pipewire', 'alsa', 'pulse', 'sndio', 'oss' or 'shmem'
+# Defaults to 'oss', 'sndio', 'pipewire', 'pulse', 'alsa', 'portaudio' or 'fifo', in that order, dependent on what support cava was built with.
 # On Mac it defaults to 'portaudio' or 'fifo'
 # On windows this is automatic and no input settings are needed.
 #
@@ -69,6 +69,13 @@
 # For alsa 'source' will be the capture device.
 # For fifo 'source' will be the path to fifo-file.
 # For shmem 'source' will be /squeezelite-AA:BB:CC:DD:EE:FF where 'AA:BB:CC:DD:EE:FF' will be squeezelite's MAC address
+#
+# For sndio 'source' will be a monitor sub-device, e.g. 'snd/0.monitor'. Default: 'default', in which case a device
+# should be specified with the environment variable AUDIODEVICE, e.g. on the commandline: AUDIODEVICE=snd/0.monitor cava.
+#
+# For oss 'source' will be the path to a audio device, e.g. '/dev/dsp2'. Default: '/dev/dsp', i.e. the default audio device.
+# README.md contains further information on how to setup CAVA for OSS on FreeBSD.
+#
 ; method = pulse
 ; source = auto
 
@@ -87,6 +94,21 @@
 ; method = portaudio
 ; source = auto
 
+; method = sndio
+; source = default
+
+; method = oss
+; source = /dev/dsp
+
+# The sample rate and format can be configured for some input methods. Currently
+# the following methods support such a configuration: 'fifo', 'pipewire' and 'oss'.
+# Other methods ignore these settings.
+#
+# For 'oss' they are only preferred values, i.e. if the values are not supported
+# by the chosen audio device, the device will use other supported values instead.
+# Example: 48000 and 32, but the device only supports 44100 and 16, then it will
+# use 44100 and 16.
+#
 ; sample_rate = 44100
 ; sample_bits = 16
 
@@ -168,6 +190,7 @@
 ; continuous_rendering = 0
 
 # disable console blank (screen saver) in tty
+# (Not supported on FreeBSD)
 ; disable_blanking = 0
 
 [color]

--- a/input/common.h
+++ b/input/common.h
@@ -24,9 +24,11 @@ struct audio_data {
     int format;
     unsigned int rate;
     unsigned int channels;
-    char *source;  // alsa device, fifo path or pulse source
-    int im;        // input mode alsa, fifo, pulse, portaudio, shmem or sndio
-    int terminate; // shared variable used to terminate audio thread
+    int threadparams; // shared variable used to prevent main thread from cava_init before input
+                      // threads have finalized parameters
+    char *source;     // alsa device, fifo path or pulse source
+    int im;           // input mode alsa, fifo, pulse, portaudio, shmem or sndio
+    int terminate;    // shared variable used to terminate audio thread
     char error_message[1024];
     int samples_counter;
     int IEEE_FLOAT;

--- a/input/oss.c
+++ b/input/oss.c
@@ -1,0 +1,185 @@
+#include <stdbool.h>
+#include <stddef.h>
+
+#include <sys/ioctl.h>
+#include <sys/soundcard.h>
+
+#include "input/common.h"
+#include "input/oss.h"
+
+static bool set_format(int fd, struct audio_data *audio) {
+    // CAVA favors signed and little endian (sle) formats. It might actually not work correctly if
+    // we feed it an unsigned or big endian format. Therefore we prefer to select one of the
+    // supported sle formats, if any exist.
+
+    // The favored sle formats. 16bit has priority, followed by "bigger is better".
+    static const int fmts_sle[] = {AFMT_S16_LE, AFMT_S32_LE, AFMT_S24_LE, AFMT_S8};
+
+    // Bitmasks of formats categorized by bitlength.
+    static const int fmts_8bits = AFMT_U8 | AFMT_S8;
+    static const int fmts_16bits = AFMT_S16_LE | AFMT_S16_BE | AFMT_U16_LE | AFMT_U16_BE;
+    static const int fmts_24bits = AFMT_S24_LE | AFMT_S24_BE | AFMT_U24_LE | AFMT_U24_BE;
+    static const int fmts_32bits = AFMT_S32_LE | AFMT_S32_BE | AFMT_U32_LE | AFMT_U32_BE;
+
+    int fmts;
+    int fmt;
+
+    // Get all supported formats from the audio device.
+    if (ioctl(fd, SNDCTL_DSP_GETFMTS, &fmts) == -1) {
+        fprintf(stderr, __FILE__ ": ioctl(SNDCTL_DSP_GETFMTS) failed: %s\n", strerror(errno));
+        return false;
+    }
+
+    // Determine the sle format for the requested bitlength.
+    if (audio->format <= 8)
+        fmt = AFMT_S8;
+    else if (audio->format <= 16)
+        fmt = AFMT_S16_LE;
+    else if (audio->format <= 24)
+        fmt = AFMT_S24_LE;
+    else
+        fmt = AFMT_S32_LE;
+
+    // If the requested format is not available then test for the other sle formats.
+    if (!(fmts & fmt)) {
+        for (size_t i = 0; i < sizeof(fmts_sle) / sizeof(fmts_sle[0]); ++i) {
+            if (fmts & fmts_sle[i]) {
+                fmt = fmts_sle[i];
+                break;
+            }
+        }
+    }
+
+    // Set the format of the device. If not supported then OSS will adjust to a supported format.
+    if (ioctl(fd, SNDCTL_DSP_SETFMT, &fmt) == -1) {
+        fprintf(stderr, __FILE__ ": ioctl(SNDCTL_DSP_SETFMT) failed: %s\n", strerror(errno));
+        return false;
+    }
+
+    // Determine the actual bitlength of the returned format.
+    if (fmts_8bits & fmt)
+        audio->format = 8;
+    else if (fmts_16bits & fmt)
+        audio->format = 16;
+    else if (fmts_24bits & fmt)
+        audio->format = 24;
+    else if (fmts_32bits & fmt)
+        audio->format = 32;
+    else {
+        fprintf(stderr, __FILE__ ": No support for 8, 16, 24 or 32 bits in OSS source '%s'.\n",
+                audio->source);
+        return false;
+    }
+
+    return true;
+}
+
+static bool set_channels(int fd, struct audio_data *audio) {
+    // Try to set the requested channels, OSS will adjust to a supported value. If CAVA doesn't
+    // support the final value then it will complain later.
+    int channels = audio->channels;
+
+    if (ioctl(fd, SNDCTL_DSP_CHANNELS, &channels) == -1) {
+        fprintf(stderr, __FILE__ ": ioctl(SNDCTL_DSP_CHANNELS) failed: %s\n", strerror(errno));
+        return false;
+    }
+
+    audio->channels = channels;
+
+    return true;
+}
+
+static bool set_rate(int fd, struct audio_data *audio) {
+    // Try to set the requested rate, OSS will adjust to a supported value. If CAVA doesn't support
+    // the final value then it will complain later.
+    int rate = audio->rate;
+
+    if (ioctl(fd, SNDCTL_DSP_SPEED, &rate) == -1) {
+        fprintf(stderr, __FILE__ ": ioctl(SNDCTL_DSP_SPEED) failed: %s\n", strerror(errno));
+        return false;
+    }
+
+    audio->rate = rate;
+
+    return true;
+}
+
+static void signal_threadparams(struct audio_data *audio) {
+    pthread_mutex_lock(&audio->lock);
+    audio->threadparams = 0;
+    pthread_mutex_unlock(&audio->lock);
+}
+
+static void signal_terminate(struct audio_data *audio) {
+    pthread_mutex_lock(&audio->lock);
+    audio->terminate = 1;
+    pthread_mutex_unlock(&audio->lock);
+}
+
+void *input_oss(void *data) {
+    static const int flags = O_RDONLY;
+
+    struct audio_data *audio = (struct audio_data *)data;
+    int bytes;
+    size_t buf_size;
+    ssize_t rd;
+
+    int fd = -1;
+    void *buf = NULL;
+
+    bool success = false;
+
+    if ((fd = open(audio->source, flags, 0)) == -1) {
+        fprintf(stderr, __FILE__ ": Could not open OSS source '%s': %s\n", audio->source,
+                strerror(errno));
+        goto cleanup;
+    }
+
+    // For OSS it's adviced to determine format, channels and rate in this order.
+    if (!(set_format(fd, audio) && set_channels(fd, audio) && set_rate(fd, audio)))
+        goto cleanup;
+
+    // Parameters finalized. Signal main thread.
+    signal_threadparams(audio);
+
+    // OSS uses 32 bits for 24bit.
+    if (audio->format == 24)
+        bytes = 4; // = 32 / 8
+    else
+        bytes = audio->format / 8;
+
+    buf_size = audio->input_buffer_size * bytes;
+
+    if ((buf = malloc(buf_size)) == NULL) {
+        fprintf(stderr, __FILE__ ": malloc() failed: %s\n", strerror(errno));
+        goto cleanup;
+    }
+
+    while (audio->terminate != 1) {
+        if ((rd = read(fd, buf, buf_size)) == -1) {
+            fprintf(stderr, __FILE__ ": read() failed: %s\n", strerror(errno));
+            goto cleanup;
+        } else if (rd == 0)
+            signal_terminate(audio);
+        else
+            write_to_cava_input_buffers(rd / bytes, buf, audio);
+    }
+
+    success = true;
+
+cleanup:
+    free(buf);
+
+    if ((fd >= 0) && (close(fd) == -1)) {
+        fprintf(stderr, __FILE__ ": close() failed: %s\n", strerror(errno));
+        success = false;
+    }
+
+    signal_threadparams(audio);
+    signal_terminate(audio);
+
+    if (!success)
+        exit(EXIT_FAILURE);
+
+    return NULL;
+}

--- a/input/oss.h
+++ b/input/oss.h
@@ -1,0 +1,5 @@
+// header file for oss, part of cava.
+
+#pragma once
+
+void *input_oss(void *data);

--- a/input/sndio.c
+++ b/input/sndio.c
@@ -15,7 +15,7 @@ void *input_sndio(void *data) {
     par.le = 1;
     par.rate = audio->rate;
     ;
-    par.rchan = 2;
+    par.rchan = audio->channels;
     par.appbufsz = sizeof(buf) / par.rchan;
 
     if ((hdl = sio_open(audio->source, SIO_REC, 0)) == NULL) {

--- a/output/terminal_bcircle.c
+++ b/output/terminal_bcircle.c
@@ -77,9 +77,13 @@ int draw_terminal_bcircle(int tty, int h, int w, int f[]) {
 // general: cleanup
 void cleanup_terminal_bcircle(void) {
     echo();
+#ifdef __FreeBSD__
+    system("vidcontrol -f >/dev/null 2>&1");
+#else
     system("setfont >/dev/null 2>&1");
     system("setfont /usr/share/consolefonts/Lat2-Fixed16.psf.gz  >/dev/null 2>&1");
     system("setterm -blank 10");
+#endif
     endwin();
     system("clear");
 }

--- a/output/terminal_ncurses.c
+++ b/output/terminal_ncurses.c
@@ -311,8 +311,12 @@ int draw_terminal_ncurses(int is_tty, int dimension_value, int dimension_bar, in
 // general: cleanup
 void cleanup_terminal_ncurses(void) {
     echo();
+#ifdef __FreeBSD__
+    system("vidcontrol -f >/dev/null 2>&1");
+#else
     system("setfont  >/dev/null 2>&1");
     system("setfont /usr/share/consolefonts/Lat2-Fixed16.psf.gz  >/dev/null 2>&1");
+#endif
 
     /*for(int i = 0; i < gradient_size; ++i) {
             if(the_color_redefinitions[i].color) {

--- a/output/terminal_noncurses.c
+++ b/output/terminal_noncurses.c
@@ -158,7 +158,9 @@ int init_terminal_noncurses(int tty, char *const fg_color_string, char *const bg
     system("cls");
 
 #else
+#ifndef __FreeBSD__
     system("setterm -cursor off");
+#endif
     system("clear");
 #endif
 
@@ -418,9 +420,13 @@ void cleanup_terminal_noncurses(void) {
     system("cls");
 #else
     setecho(STDIN_FILENO, 1);
+#ifdef __FreeBSD__
+    system("vidcontrol -f >/dev/null 2>&1");
+#else
     system("setfont  >/dev/null 2>&1");
     system("setfont /usr/share/consolefonts/Lat2-Fixed16.psf.gz  >/dev/null 2>&1");
     system("setterm -cursor on");
+#endif
     system("clear");
 #endif
     printf("\033[0m\n");


### PR DESCRIPTION
- OSS: add 'enable-oss-input' configure option
- OSS: set to default input method if enabled
- sndio: add to input method selection sequence with high priority
- sndio: fix small bug in channel setting
- FreeBSD: add 'enable-cava-font' configure option, which creates vt(4) font cava.fnt from cava.psf
- doc: extended documentation in example config file and in README.md