### PR TITLE
Fix typo on cava.c

### DIFF
--- a/cava.c
+++ b/cava.c
@@ -483,7 +483,7 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
             if (timeout_counter > 2000) {
                 cleanup();
                 fprintf(stderr, "could not get rate and/or format, problems with audio thread? "
-                                "quiting...\n");
+                                "quitting...\n");
                 exit(EXIT_FAILURE);
             }
         }


### PR DESCRIPTION
The patch is currently applied to the cava-alsa package on debian