### PR TITLE
Fix crash when using pulseaudio

### DIFF
--- a/input/pulse.c
+++ b/input/pulse.c
@@ -26,7 +26,6 @@ void cb(__attribute__((unused)) pa_context *pulseaudio_context, const pa_server_
     pa_context_disconnect(pulseaudio_context);
     pa_context_unref(pulseaudio_context);
     pa_mainloop_quit(m_pulseaudio_mainloop, 0);
-    pa_mainloop_free(m_pulseaudio_mainloop);
 }
 
 void pulseaudio_context_state_callback(pa_context *pulseaudio_context, void *userdata) {
@@ -96,6 +95,7 @@ void getPulseDefaultSink(void *data) {
     }
 
     pa_mainloop_run(m_pulseaudio_mainloop, &ret);
+    pa_mainloop_free(m_pulseaudio_mainloop);
 }
 
 void *input_pulse(void *data) {


### PR DESCRIPTION
The main loop should be freed only after it has stopped running.

I get a segmentation fault on macOS without this patch.