### PR TITLE
Synchronized Sync (Mode 2026)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ missing
 version
 config_file.h
 .*
+cava

--- a/cava.c
+++ b/cava.c
@@ -1098,10 +1098,9 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
 
 // output: draw processed input
 #ifdef NDEBUG
-                if (p.sync_updates) {
-                    printf("\033Ptmux;\033\033[?2026h");
-                    fflush(stdout);
-                }
+                printf("\033P[2026;2$y");
+                fflush(stdout);
+
                 int rc;
 #ifdef _MSC_VER
                 QueryPerformanceCounter(&t1);
@@ -1148,11 +1147,10 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
                 default:
                     exit(EXIT_FAILURE); // Can't happen.
                 }
-                if (p.sync_updates) {
-                    printf("\033Ptmux;\033\033[?2026h");
-                    fflush(stdout);
-                }
 
+                printf("\033P[2026;2$y");
+                fflush(stdout);
+                
                 // terminal has been resized breaking to recalibrating values
                 if (rc == -1)
                     resizeTerminal = true;

--- a/cava.c
+++ b/cava.c
@@ -1098,9 +1098,9 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
 
 // output: draw processed input
 #ifdef NDEBUG
-                printf("\033P[2026;2$y\033[0m");
+                printf("\033P[2026h;2$y\033[0m");
                 fflush(stdout);
-
+                
                 int rc;
 #ifdef _MSC_VER
                 QueryPerformanceCounter(&t1);

--- a/cava.c
+++ b/cava.c
@@ -1108,10 +1108,11 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
 
 // output: draw processed input
 #ifdef NDEBUG
-                printf("\033[2026h\033\\");
-                fflush(stdout);
-                printf("\033[2026l\033\\");
-
+                if (p.sync_updates) {
+                    printf("\033[2026h\033\\");
+                    fflush(stdout);
+                    printf("\033[2026l\033\\");
+                }
                 int rc;
 #ifdef _MSC_VER
                 QueryPerformanceCounter(&t1);
@@ -1176,7 +1177,6 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
                     fflush(stdout);
                     printf("\033[2026l\033\\");
                 }
-                
                 // terminal has been resized breaking to recalibrating values
                 if (rc == -1)
                     resizeTerminal = true;

--- a/cava.c
+++ b/cava.c
@@ -1171,9 +1171,11 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
                     exit(EXIT_FAILURE); // Can't happen.
                 }
 
-                printf("\033[2026h\033\\");
-                fflush(stdout);
-                printf("\033[2026l\033\\");
+                if (p.sync_updates) {
+                    printf("\033[2026h\033\\");
+                    fflush(stdout);
+                    printf("\033[2026l\033\\");
+                }
                 
                 // terminal has been resized breaking to recalibrating values
                 if (rc == -1)

--- a/cava.c
+++ b/cava.c
@@ -1099,7 +1099,7 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
 // output: draw processed input
 #ifdef NDEBUG
                 if (p.sync_updates) {
-                    printf("\033P=1s\033\\");
+                    printf("\033Ptmux;\033\033[?2026h");
                     fflush(stdout);
                 }
                 int rc;
@@ -1149,7 +1149,7 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
                     exit(EXIT_FAILURE); // Can't happen.
                 }
                 if (p.sync_updates) {
-                    printf("\033P=2s\033\\");
+                    printf("\033Ptmux;\033\033[?2026h");
                     fflush(stdout);
                 }
 

--- a/cava.c
+++ b/cava.c
@@ -1098,9 +1098,10 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
 
 // output: draw processed input
 #ifdef NDEBUG
-                printf("\033P[2026h;2$y\033[0m");
+                printf("\033[2026h\033\\");
                 fflush(stdout);
-                
+                printf("\033[2026l\033\\");
+
                 int rc;
 #ifdef _MSC_VER
                 QueryPerformanceCounter(&t1);
@@ -1147,6 +1148,10 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
                 default:
                     exit(EXIT_FAILURE); // Can't happen.
                 }
+
+                printf("\033[2026h\033\\");
+                fflush(stdout);
+                printf("\033[2026l\033\\");
                 
                 // terminal has been resized breaking to recalibrating values
                 if (rc == -1)

--- a/cava.c
+++ b/cava.c
@@ -1098,7 +1098,7 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
 
 // output: draw processed input
 #ifdef NDEBUG
-                printf("\033P[2026;2$y");
+                printf("\033P[2026;2$y\033[0m");
                 fflush(stdout);
 
                 int rc;
@@ -1147,9 +1147,6 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
                 default:
                     exit(EXIT_FAILURE); // Can't happen.
                 }
-
-                printf("\033P[2026;2$y");
-                fflush(stdout);
                 
                 // terminal has been resized breaking to recalibrating values
                 if (rc == -1)

--- a/config.c
+++ b/config.c
@@ -687,6 +687,8 @@ bool load_config(char configPath[PATH_MAX], struct config_params *p, bool colors
 
     p->waveform = iniparser_getint(ini, "output:waveform", 0);
 
+    p->sync_updates = iniparser_getint(ini, "output:synchronized_sync", 0);
+
     vertexShader = strdup(iniparser_getstring(ini, "output:vertex_shader", "pass_through.vert"));
     fragmentShader =
         strdup(iniparser_getstring(ini, "output:fragment_shader", "bar_spectrum.frag"));
@@ -830,6 +832,7 @@ bool load_config(char configPath[PATH_MAX], struct config_params *p, bool colors
     p->sdl_x = GetPrivateProfileInt("output", "sdl_x", -1, configPath);
     p->sdl_y = GetPrivateProfileInt("output", "sdl_y", -1, configPath);
 
+    p->sync_updates = GetPrivateProfileInt("output", "synchronized_sync", 0, configPath);
     p->show_idle_bar_heads = GetPrivateProfileInt("output", "show_idle_bar_heads", 1, configPath);
     p->waveform = GetPrivateProfileInt("output", "waveform", 0, configPath);
 

--- a/config.c
+++ b/config.c
@@ -666,8 +666,6 @@ bool load_config(char configPath[PATH_MAX], struct config_params *p, bool colors
 
     p->waveform = iniparser_getint(ini, "output:waveform", 0);
 
-    p->sync_updates = iniparser_getint(ini, "output:alacritty_sync", 0);
-
     vertexShader = strdup(iniparser_getstring(ini, "output:vertex_shader", "pass_through.vert"));
     fragmentShader =
         strdup(iniparser_getstring(ini, "output:fragment_shader", "bar_spectrum.frag"));
@@ -811,7 +809,6 @@ bool load_config(char configPath[PATH_MAX], struct config_params *p, bool colors
     p->sdl_x = GetPrivateProfileInt("output", "sdl_x", -1, configPath);
     p->sdl_y = GetPrivateProfileInt("output", "sdl_y", -1, configPath);
 
-    p->sync_updates = GetPrivateProfileInt("output", "alacritty_sync", 0, configPath);
     p->show_idle_bar_heads = GetPrivateProfileInt("output", "show_idle_bar_heads", 1, configPath);
     p->waveform = GetPrivateProfileInt("output", "waveform", 0, configPath);
 

--- a/config.h
+++ b/config.h
@@ -120,7 +120,7 @@ struct config_params {
         bit_format, gradient, gradient_count, fixedbars, framerate, bar_width, bar_spacing,
         bar_height, autosens, overshoot, waves, samplerate, samplebits, channels, autoconnect,
         sleep_timer, sdl_width, sdl_height, sdl_x, sdl_y, sdl_full_screen, draw_and_quit, zero_test,
-        non_zero_test, reverse, continuous_rendering, disable_blanking,
+        non_zero_test, reverse, sync_updates, continuous_rendering, disable_blanking,
         show_idle_bar_heads, waveform;
 };
 

--- a/config.h
+++ b/config.h
@@ -113,7 +113,7 @@ struct config_params {
         bit_format, gradient, gradient_count, fixedbars, framerate, bar_width, bar_spacing,
         bar_height, autosens, overshoot, waves, samplerate, samplebits, channels, autoconnect,
         sleep_timer, sdl_width, sdl_height, sdl_x, sdl_y, sdl_full_screen, draw_and_quit, zero_test,
-        non_zero_test, reverse, sync_updates, continuous_rendering, disable_blanking,
+        non_zero_test, reverse, continuous_rendering, disable_blanking,
         show_idle_bar_heads, waveform;
 };
 

--- a/example_files/config
+++ b/example_files/config
@@ -189,12 +189,11 @@
 # 'frequency' displays the lower cut off frequency of the bar above.
 # Only supported on ncurses and noncurses output.
 ; xaxis = none
-
-# Deprecated
-# enable alacritty synchronized updates. 1 = on, 0 = off
+ 
+# enable synchronized synchronized updates. 1 = on, 0 = off
 # removes flickering in alacritty terminal emulator.
 # defaults to off since the behaviour in other terminal emulators is unknown
-; alacritty_sync = 0
+; synchronized_sync = 0
 
 # Shaders for sdl_glsl, located in $HOME/.config/cava/shaders
 ; vertex_shader = pass_through.vert

--- a/example_files/config
+++ b/example_files/config
@@ -190,7 +190,7 @@
 # Only supported on ncurses and noncurses output.
 ; xaxis = none
  
-# enable synchronized synchronized updates. 1 = on, 0 = off
+# enable synchronized sync. 1 = on, 0 = off
 # removes flickering in alacritty terminal emulator.
 # defaults to off since the behaviour in other terminal emulators is unknown
 ; synchronized_sync = 0

--- a/example_files/config
+++ b/example_files/config
@@ -188,6 +188,7 @@
 # Only supported on ncurses and noncurses output.
 ; xaxis = none
 
+# Deprecated
 # enable alacritty synchronized updates. 1 = on, 0 = off
 # removes flickering in alacritty terminal emulator.
 # defaults to off since the behaviour in other terminal emulators is unknown


### PR DESCRIPTION
Deprecates the Alacritty synchronization option for Mode 2026 (https://gist.github.com/christianparpart/d8a62cc1ab659194337d73e399004036)