### PR TITLE
Fix unlinked issue in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,7 +616,7 @@ Actually, `setfont` is supposed to return the default font, but this usually isn
 
 ### Gradient not working in Konsole
 
-Konsole simply does not support this. #194
+Konsole simply does not support this. [#194](https://github.com/karlstav/cava/issues/194)
 
 Usage
 -----


### PR DESCRIPTION
While skimming through the README, I noticed the following segment

> ### Gradient not working in Konsole
> Konsole simply does not support this. #​194

I tried to click on the issue, but then remembered that GitHub doesn't support directly linking Issues/PRs in markdown files, only from other Issues of PRs. This PR just adds a link to #​194 
on the text, for user convince (See below).

# Before:
![image](https://github.com/user-attachments/assets/6f55a988-9928-439e-9331-5de59a88f7e8)

# After:
![image](https://github.com/user-attachments/assets/a7ba36ec-2bd1-4526-be1b-ea9de752cda2)
