### PR TITLE
the debian package is now in stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Cava is in [AUR](https://aur.archlinux.org/packages/cava/).
 
 #### Ubuntu/Debian
 
-##### Ubuntu 20.10 or more recent / Debian (unstable)
+##### Ubuntu 20.10 or more recent / Debian 12 (Bookworm)
 
     sudo apt install cava
     


### PR DESCRIPTION
just so that people know that they don't have to use Debian 13 (Trixie) to install _cava_