### PR TITLE
feat: Better Windows Support

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,5 @@
 name: build-and-test
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,4 @@ missing
 version
 config_file.h
 .*
-cava
 *.user

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ version
 config_file.h
 .*
 cava
+*.user

--- a/cava.c
+++ b/cava.c
@@ -637,6 +637,7 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
                     strcat(pipePath, p.raw_target);
                     DWORD pipeMode = strcmp(p.data_format, "ascii") ? PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE : PIPE_TYPE_BYTE | PIPE_READMODE_BYTE;
                     hFile = CreateNamedPipeA(pipePath, PIPE_ACCESS_OUTBOUND | FILE_FLAG_OVERLAPPED, pipeMode | PIPE_NOWAIT, PIPE_UNLIMITED_INSTANCES, 0, 0, NMPWAIT_USE_DEFAULT_WAIT, NULL);
+                    free(pipePath);
 #endif
                 } else {
 #ifndef _MSC_VER

--- a/cava.c
+++ b/cava.c
@@ -292,7 +292,7 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
     int c;
     while ((c = getopt(argc, argv, "p:vh")) != -1) {
         switch (c) {
-        case 'p': // argument: fifo path
+        case 'p': // argument: config path
             snprintf(configPath, sizeof(configPath), "%s", optarg);
             break;
         case 'h': // argument: print usage
@@ -660,8 +660,8 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
                                          ? PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE
                                          : PIPE_TYPE_BYTE | PIPE_READMODE_BYTE;
                     hFile = CreateNamedPipeA(pipePath, PIPE_ACCESS_OUTBOUND | FILE_FLAG_OVERLAPPED,
-                                             pipeMode | PIPE_NOWAIT, PIPE_UNLIMITED_INSTANCES, 0,
-                                             0, +NMPWAIT_USE_DEFAULT_WAIT, NULL);
+                                             pipeMode | PIPE_NOWAIT, PIPE_UNLIMITED_INSTANCES, 0, 0, 
+                                             NMPWAIT_USE_DEFAULT_WAIT, NULL);
                     free(pipePath);
 #endif
                 } else {

--- a/cava.c
+++ b/cava.c
@@ -57,6 +57,8 @@
 #include "input/common.h"
 
 #include "output/terminal_noncurses.h"
+#include "output/noritake.h"
+#include "output/raw.h"
 
 #ifndef _MSC_VER
 #ifdef NCURSES
@@ -64,9 +66,6 @@
 #include "output/terminal_ncurses.h"
 #include <curses.h>
 #endif
-
-#include "output/noritake.h"
-#include "output/raw.h"
 
 #include "input/alsa.h"
 #include "input/fifo.h"
@@ -531,7 +530,7 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
         int height, lines, width, remainder, fp;
         int *dimension_bar, *dimension_value;
 #ifdef _MSC_VER
-        HANDLE hFile;
+        HANDLE hFile = NULL;
 #endif
 
         if (p.orientation == ORIENT_LEFT || p.orientation == ORIENT_RIGHT) {

--- a/cava.c
+++ b/cava.c
@@ -660,7 +660,7 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
                                          ? PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE
                                          : PIPE_TYPE_BYTE | PIPE_READMODE_BYTE;
                     hFile = CreateNamedPipeA(pipePath, PIPE_ACCESS_OUTBOUND | FILE_FLAG_OVERLAPPED,
-                                             pipeMode | PIPE_NOWAIT, PIPE_UNLIMITED_INSTANCES, 0, 0, 
+                                             pipeMode | PIPE_NOWAIT, PIPE_UNLIMITED_INSTANCES, 0, 0,
                                              NMPWAIT_USE_DEFAULT_WAIT, NULL);
                     free(pipePath);
 #endif

--- a/cava_win/cava/cava.rc
+++ b/cava_win/cava/cava.rc
@@ -1,0 +1,14 @@
+#define TEXTFILE 256
+#define IDR_CONFIG_FILE 101
+#define IDR_BAR_SPECTRUM_SHADER 102
+#define IDR_NORTHERN_LIGHTS_SHADER 103
+#define IDR_PASS_THROUGH_SHADER 104
+#define IDR_SPECTROGRAM_SHADER 105
+#define IDR_WINAMP_LINE_STYLE_SPECTRUM_SHADER 106
+
+IDR_CONFIG_FILE TEXTFILE "../../example_files/config"
+IDR_BAR_SPECTRUM_SHADER TEXTFILE "../../output/shaders/bar_spectrum.frag"
+IDR_NORTHERN_LIGHTS_SHADER TEXTFILE "../../output/shaders/northern_lights.frag"
+IDR_PASS_THROUGH_SHADER TEXTFILE "../../output/shaders/pass_through.vert"
+IDR_SPECTROGRAM_SHADER TEXTFILE "../../output/shaders/spectrogram.frag"
+IDR_WINAMP_LINE_STYLE_SPECTRUM_SHADER TEXTFILE "../../output/shaders/winamp_line_style_spectrum.frag"

--- a/cava_win/cava/cava.vcxproj
+++ b/cava_win/cava/cava.vcxproj
@@ -123,7 +123,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>opengl32.lib;$(SolutionDir)\packages\glew.1.9.0.1\build\native\lib\v110\x64\Debug\dynamic\glew.lib;$(SolutionDir)\packages\pthreads.2.9.1.4\build\native\lib\v110\x64\Debug\dynamic\cdecl\libpthread.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>opengl32.lib;Shlwapi.lib;$(SolutionDir)\packages\glew.1.9.0.1\build\native\lib\v110\x64\Debug\dynamic\glew.lib;$(SolutionDir)\packages\pthreads.2.9.1.4\build\native\lib\v110\x64\Debug\dynamic\cdecl\libpthread.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PreBuildEvent>
@@ -135,10 +135,12 @@
       </Message>
     </PreBuildEvent>
     <PostBuildEvent>
-      <Command>xcopy /Y /D $(SolutionDir)\..\example_files\config $(ProjectDir)</Command>
+      <Command>
+      </Command>
     </PostBuildEvent>
     <PostBuildEvent>
-      <Message>add config file</Message>
+      <Message>
+      </Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -156,7 +158,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>opengl32.lib;$(SolutionDir)\packages\glew.1.9.0.1\build\native\lib\v110\x64\Release\dynamic\glew.lib;$(SolutionDir)\packages\pthreads.2.9.1.4\build\native\lib\v110\x64\Release\dynamic\cdecl\libpthread.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>opengl32.lib;Shlwapi.lib;$(SolutionDir)\packages\glew.1.9.0.1\build\native\lib\v110\x64\Release\dynamic\glew.lib;$(SolutionDir)\packages\pthreads.2.9.1.4\build\native\lib\v110\x64\Release\dynamic\cdecl\libpthread.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PreBuildEvent>
@@ -166,10 +168,12 @@
       </Message>
     </PreBuildEvent>
     <PostBuildEvent>
-      <Command>xcopy /Y /D $(SolutionDir)\..\example_files\config $(ProjectDir)</Command>
+      <Command>
+      </Command>
     </PostBuildEvent>
     <PostBuildEvent>
-      <Message>add config file</Message>
+      <Message>
+      </Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -198,8 +202,10 @@
     <ClInclude Include="..\..\util.h" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="config" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="cava.rc" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/cava_win/cava/cava.vcxproj
+++ b/cava_win/cava/cava.vcxproj
@@ -181,6 +181,8 @@
     <ClCompile Include="..\..\output\sdl_cava.c" />
     <ClCompile Include="..\..\output\sdl_glsl.c" />
     <ClCompile Include="..\..\output\terminal_noncurses.c" />
+    <ClCompile Include="..\..\output\raw.c" />
+    <ClCompile Include="..\..\output\noritake.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\cavacore.h" />
@@ -191,6 +193,8 @@
     <ClInclude Include="..\..\output\sdl_cava.h" />
     <ClInclude Include="..\..\output\sdl_glsl.h" />
     <ClInclude Include="..\..\output\terminal_noncurses.h" />
+    <ClInclude Include="..\..\output\raw.h" />
+    <ClInclude Include="..\..\output\noritake.h" />
     <ClInclude Include="..\..\util.h" />
   </ItemGroup>
   <ItemGroup>

--- a/config.c
+++ b/config.c
@@ -46,9 +46,9 @@ static void LoadFileInResource(int name, int type, DWORD *size, const char **dat
     }
 }
 
-int default_shader_data[NUMBER_OF_SHADERS] = {
-    IDR_BAR_SPECTRUM_SHADER, IDR_NORTHERN_LIGHTS_SHADER, IDR_PASS_THROUGH_SHADER,
-    IDR_SPECTROGRAM_SHADER, IDR_WINAMP_LINE_STYLE_SPECTRUM_SHADER};
+int default_shader_data[NUMBER_OF_SHADERS] = {IDR_BAR_SPECTRUM_SHADER, IDR_NORTHERN_LIGHTS_SHADER,
+                                              IDR_PASS_THROUGH_SHADER, IDR_SPECTROGRAM_SHADER,
+                                              IDR_WINAMP_LINE_STYLE_SPECTRUM_SHADER};
 #else
 #define INCBIN_SILENCE_BITCODE_WARNING
 #include "third_party/incbin.h"
@@ -523,7 +523,8 @@ bool load_config(char configPath[PATH_MAX], struct config_params *p, bool colors
         }
     } else { // opening specified file
 #ifdef _MSC_VER
-        if (PathIsRelativeA(configPath) == TRUE) { //GetPrivateProfileString does not accept relative paths
+        // GetPrivateProfileString does not accept relative paths
+        if (PathIsRelativeA(configPath) == TRUE) {
             char newPath[PATH_MAX];
             GetCurrentDirectoryA(PATH_MAX - 1 - strlen(configPath), newPath);
             strcat(newPath, "\\");

--- a/config.c
+++ b/config.c
@@ -21,8 +21,8 @@
 #define NUMBER_OF_SHADERS 5
 
 #ifdef _MSC_VER
-#include "Windows.h"
 #include "Shlwapi.h"
+#include "Windows.h"
 #define TEXTFILE 256
 #define IDR_CONFIG_FILE 101
 #define PATH_MAX 260
@@ -503,16 +503,6 @@ bool load_config(char configPath[PATH_MAX], struct config_params *p, bool colors
             }
             fclose(fp);
         } else {
-#ifdef _MSC_VER
-            if (PathIsRelativeA(configPath) == TRUE)
-            {
-                char newPath[PATH_MAX];
-                GetCurrentDirectoryA(PATH_MAX - 1 - strlen(configPath), newPath);
-                strcat(newPath, "\\");
-                strcat(newPath, configPath);
-                configPath = newPath;
-            }
-#endif
             // try to open file read only
             fp = fopen(configPath, "rb");
             if (fp) {
@@ -523,6 +513,16 @@ bool load_config(char configPath[PATH_MAX], struct config_params *p, bool colors
             }
         }
     } else { // opening specified file
+#ifdef _MSC_VER
+        if (PathIsRelativeA(configPath) == TRUE) { //GetPrivateProfileString does not accept relative paths
+            char newPath[PATH_MAX];
+            GetCurrentDirectoryA(PATH_MAX - 1 - strlen(configPath), newPath);
+            strcat(newPath, "\\");
+            strcat(newPath, configPath);
+            memset(configPath, 0, sizeof(configPath));
+            strcpy(configPath, newPath);
+        }
+#endif
         fp = fopen(configPath, "rb");
         if (fp) {
             fclose(fp);

--- a/config.c
+++ b/config.c
@@ -46,9 +46,10 @@ static void LoadFileInResource(int name, int type, DWORD *size, const char **dat
     }
 }
 
-int default_shader_data[NUMBER_OF_SHADERS] = {IDR_BAR_SPECTRUM_SHADER, IDR_NORTHERN_LIGHTS_SHADER,
-                                              IDR_PASS_THROUGH_SHADER, IDR_SPECTROGRAM_SHADER,
-                                              IDR_WINAMP_LINE_STYLE_SPECTRUM_SHADER};
+int default_shader_data[NUMBER_OF_SHADERS] = {IDR_NORTHERN_LIGHTS_SHADER, IDR_PASS_THROUGH_SHADER,
+                                              IDR_BAR_SPECTRUM_SHADER,
+                                              IDR_WINAMP_LINE_STYLE_SPECTRUM_SHADER,
+                                              IDR_SPECTROGRAM_SHADER};
 #else
 #define INCBIN_SILENCE_BITCODE_WARNING
 #include "third_party/incbin.h"

--- a/config.c
+++ b/config.c
@@ -46,10 +46,9 @@ static void LoadFileInResource(int name, int type, DWORD *size, const char **dat
     }
 }
 
-int default_shader_data[NUMBER_OF_SHADERS] = {IDR_NORTHERN_LIGHTS_SHADER, IDR_PASS_THROUGH_SHADER,
-                                              IDR_BAR_SPECTRUM_SHADER,
-                                              IDR_WINAMP_LINE_STYLE_SPECTRUM_SHADER,
-                                              IDR_SPECTROGRAM_SHADER};
+int default_shader_data[NUMBER_OF_SHADERS] = {
+    IDR_NORTHERN_LIGHTS_SHADER, IDR_PASS_THROUGH_SHADER, IDR_BAR_SPECTRUM_SHADER,
+    IDR_WINAMP_LINE_STYLE_SPECTRUM_SHADER, IDR_SPECTROGRAM_SHADER};
 #else
 #define INCBIN_SILENCE_BITCODE_WARNING
 #include "third_party/incbin.h"

--- a/example_files/config
+++ b/example_files/config
@@ -161,7 +161,9 @@
 ; mono_option = average
 ; reverse = 0
 
-# Raw output target. A fifo will be created if target does not exist.
+# Raw output target.
+# On Linux, a fifo will be created if target does not exist.
+# On Windows, a named pipe will be created if target does not exist.
 ; raw_target = /dev/stdout
 
 # Raw data format. Can be 'binary' or 'ascii'.

--- a/output/noritake.c
+++ b/output/noritake.c
@@ -34,16 +34,16 @@ int print_ntk_out(int bars_count, HANDLE hFile, int bit_format, int bar_width, i
 #ifndef _MSC_VER
                 write(fd, &buf_8, sizeof(int8_t));
 #else
-                WriteFile(hFile, &buf_8, sizeof(int8_t), NULL, NULL));
+                WriteFile(hFile, &buf_8, sizeof(int8_t), NULL, NULL);
 #endif
             }
         }
         buf_8 = 0;
         for (j = 0; j < bar_height / 8 * bar_spacing; j++) {
-#ifndef
+#ifndef _MSC_VER
             write(fd, &buf_8, sizeof(int8_t));
 #else
-            WriteFile(hFile, &buf_8, sizeof(int8_t), NULL, NULL));
+            WriteFile(hFile, &buf_8, sizeof(int8_t), NULL, NULL);
 #endif
         }
     }

--- a/output/noritake.c
+++ b/output/noritake.c
@@ -1,11 +1,19 @@
+#include "noritake.h"
 #include "../config.h"
 #include <math.h>
 #include <stdint.h>
 #include <stdio.h>
+#ifndef _MSC_VER
 #include <unistd.h>
 
 int print_ntk_out(int bars_count, int fd, int bit_format, int bar_width, int bar_spacing,
                   int bar_height, int const f[]) {
+#else
+#define _CRT_SECURE_NO_WARNINGS 1
+
+int print_ntk_out(int bars_count, HANDLE hFile, int bit_format, int bar_width, int bar_spacing,
+                  int bar_height, int const f[]) {
+#endif
     int8_t buf_8;
     int8_t val1;
     uint64_t bits;
@@ -23,12 +31,20 @@ int print_ntk_out(int bars_count, int fd, int bit_format, int bar_width, int bar
         for (k = 0; k < bar_width; k++) {
             for (j = 0; j < bar_height / 8; j++) {
                 buf_8 = bits >> (8 * (bar_height / 8 - 1 - j)) & 0xff;
+#ifndef _MSC_VER
                 write(fd, &buf_8, sizeof(int8_t));
+#else
+                WriteFile(hFile, &buf_8, sizeof(int8_t), NULL, NULL));
+#endif
             }
         }
         buf_8 = 0;
         for (j = 0; j < bar_height / 8 * bar_spacing; j++) {
+#ifndef
             write(fd, &buf_8, sizeof(int8_t));
+#else
+            WriteFile(hFile, &buf_8, sizeof(int8_t), NULL, NULL));
+#endif
         }
     }
     return 0;

--- a/output/noritake.h
+++ b/output/noritake.h
@@ -2,7 +2,7 @@
 int print_ntk_out(int bars_count, int fd, int bit_format, int bar_width, int bar_spacing,
                   int bar_height, int const f[]);
 #else
-#Include "Windows.h"
+#include "Windows.h"
 int print_ntk_out(int bars_count, HANDLE hFile, int bit_format, int bar_width, int bar_spacing,
                   int bar_height, int const f[]);
 #endif

--- a/output/noritake.h
+++ b/output/noritake.h
@@ -1,2 +1,8 @@
+#ifndef _MSC_VER
 int print_ntk_out(int bars_count, int fd, int bit_format, int bar_width, int bar_spacing,
                   int bar_height, int const f[]);
+#else
+#Include "Windows.h"
+int print_ntk_out(int bars_count, HANDLE hFile, int bit_format, int bar_width, int bar_spacing,
+                  int bar_height, int const f[]);
+#endif

--- a/output/raw.c
+++ b/output/raw.c
@@ -1,10 +1,18 @@
+#include "raw.h"
 #include <math.h>
 #include <stdint.h>
 #include <stdio.h>
+#ifndef _MSC_VER
 #include <unistd.h>
 
 int print_raw_out(int bars_count, int fd, int is_binary, int bit_format, int ascii_range,
                   char bar_delim, char frame_delim, int const f[]) {
+#else
+#define _CRT_SECURE_NO_WARNINGS 1
+
+int print_raw_out(int bars_count, HANDLE hFile, int is_binary, int bit_format, int ascii_range,
+                  char bar_delim, char frame_delim, int const f[]) {
+#endif
     int16_t buf_16;
     int8_t buf_8;
     if (is_binary) {
@@ -16,11 +24,19 @@ int print_raw_out(int bars_count, int fd, int is_binary, int bit_format, int asc
             switch (bit_format) {
             case 16:
                 buf_16 = f_limited;
+#ifndef _MSC_VER
                 write(fd, &buf_16, sizeof(int16_t));
+#else
+                WriteFile(hFile, &buf_16, sizeof(int16_t), NULL, NULL));
+#endif
                 break;
             case 8:
                 buf_8 = f_limited;
+#ifndef _MSC_VER
                 write(fd, &buf_8, sizeof(int8_t));
+#else
+                WriteFile(hFile, &buf_8, sizeof(int8_t), NULL, NULL));
+#endif
                 break;
             }
         }
@@ -37,11 +53,19 @@ int print_raw_out(int bars_count, int fd, int is_binary, int bit_format, int asc
 
             char bar_height[bar_height_size];
             snprintf(bar_height, bar_height_size, "%d", f_ranged);
-
-            write(fd, bar_height, bar_height_size - 1);
-            write(fd, &bar_delim, sizeof(bar_delim));
+#ifndef _MSC_VER
+                write(fd, bar_height, bar_height_size - 1);
+                write(fd, &bar_delim, sizeof(bar_delim));
+#else
+                WriteFile(hFile, bar_height, bar_height_size - 1, NULL, NULL));
+                WriteFile(hFile, &bar_delim, sizeof(bar_delim), NULL, NULL));
+#endif
         }
+#ifndef _MSC_VER
         write(fd, &frame_delim, sizeof(frame_delim));
+#else
+        WriteFile(hFile, &frame_delim, sizeof(frame_delim), NULL, NULL));
+#endif
     }
     return 0;
 }

--- a/output/raw.c
+++ b/output/raw.c
@@ -2,6 +2,7 @@
 #include <math.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #ifndef _MSC_VER
 #include <unistd.h>
 

--- a/output/raw.c
+++ b/output/raw.c
@@ -27,7 +27,7 @@ int print_raw_out(int bars_count, HANDLE hFile, int is_binary, int bit_format, i
 #ifndef _MSC_VER
                 write(fd, &buf_16, sizeof(int16_t));
 #else
-                WriteFile(hFile, &buf_16, sizeof(int16_t), NULL, NULL));
+                WriteFile(hFile, &buf_16, sizeof(int16_t), NULL, NULL);
 #endif
                 break;
             case 8:
@@ -35,7 +35,7 @@ int print_raw_out(int bars_count, HANDLE hFile, int is_binary, int bit_format, i
 #ifndef _MSC_VER
                 write(fd, &buf_8, sizeof(int8_t));
 #else
-                WriteFile(hFile, &buf_8, sizeof(int8_t), NULL, NULL));
+                WriteFile(hFile, &buf_8, sizeof(int8_t), NULL, NULL);
 #endif
                 break;
             }
@@ -51,20 +51,21 @@ int print_raw_out(int bars_count, HANDLE hFile, int is_binary, int bit_format, i
             if (f_ranged != 0)
                 bar_height_size += floor(log10(f_ranged));
 
-            char bar_height[bar_height_size];
+            char *bar_height = malloc(bar_height_size);
             snprintf(bar_height, bar_height_size, "%d", f_ranged);
 #ifndef _MSC_VER
                 write(fd, bar_height, bar_height_size - 1);
                 write(fd, &bar_delim, sizeof(bar_delim));
 #else
-                WriteFile(hFile, bar_height, bar_height_size - 1, NULL, NULL));
-                WriteFile(hFile, &bar_delim, sizeof(bar_delim), NULL, NULL));
+                WriteFile(hFile, bar_height, bar_height_size - 1, NULL, NULL);
+                WriteFile(hFile, &bar_delim, sizeof(bar_delim), NULL, NULL);
 #endif
+                free(bar_height);
         }
 #ifndef _MSC_VER
         write(fd, &frame_delim, sizeof(frame_delim));
 #else
-        WriteFile(hFile, &frame_delim, sizeof(frame_delim), NULL, NULL));
+        WriteFile(hFile, &frame_delim, sizeof(frame_delim), NULL, NULL);
 #endif
     }
     return 0;

--- a/output/raw.c
+++ b/output/raw.c
@@ -55,13 +55,13 @@ int print_raw_out(int bars_count, HANDLE hFile, int is_binary, int bit_format, i
             char *bar_height = malloc(bar_height_size);
             snprintf(bar_height, bar_height_size, "%d", f_ranged);
 #ifndef _MSC_VER
-                write(fd, bar_height, bar_height_size - 1);
-                write(fd, &bar_delim, sizeof(bar_delim));
+            write(fd, bar_height, bar_height_size - 1);
+            write(fd, &bar_delim, sizeof(bar_delim));
 #else
-                WriteFile(hFile, bar_height, bar_height_size - 1, NULL, NULL);
-                WriteFile(hFile, &bar_delim, sizeof(bar_delim), NULL, NULL);
+            WriteFile(hFile, bar_height, bar_height_size - 1, NULL, NULL);
+            WriteFile(hFile, &bar_delim, sizeof(bar_delim), NULL, NULL);
 #endif
-                free(bar_height);
+            free(bar_height);
         }
 #ifndef _MSC_VER
         write(fd, &frame_delim, sizeof(frame_delim));

--- a/output/raw.h
+++ b/output/raw.h
@@ -2,7 +2,7 @@
 int print_raw_out(int bars_count, int fd, int is_binary, int bit_format, int ascii_range,
                   char bar_delim, char frame_delim, int const f[]);
 #else
-#Include "Windows.h"
+#include "Windows.h"
 int print_raw_out(int bars_count, HANDLE hFile, int is_binary, int bit_format, int ascii_range,
                   char bar_delim, char frame_delim, int const f[]);
 #endif

--- a/output/raw.h
+++ b/output/raw.h
@@ -1,2 +1,8 @@
+#ifndef _MSC_VER
 int print_raw_out(int bars_count, int fd, int is_binary, int bit_format, int ascii_range,
                   char bar_delim, char frame_delim, int const f[]);
+#else
+#Include "Windows.h"
+int print_raw_out(int bars_count, HANDLE hFile, int is_binary, int bit_format, int ascii_range,
+                  char bar_delim, char frame_delim, int const f[]);
+#endif


### PR DESCRIPTION
- Adds support for both `raw` and `noritake` outputs on Windows systems.
    - Supports `raw_target`:
        - If `/dev/stdout` --> `stdout` will be used
        - Else --> a named pipe will be created for output
 - Adds argument support for Windows CLI (i.e. `-p`, `-h`, etc...)
 - Adds loading config file from Windows home directory and with `-p` argument
 - Includes default config and shader files as embedded resources and writes them to disk when missing (similar to `INCTXT` on Linux but using native Windows resources)