### PR TITLE
Update installation instructions for Arch in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,9 +212,9 @@ running:
 
 #### Arch
 
-Cava is in [AUR](https://aur.archlinux.org/packages/cava/).
+Cava is available in Arch Linux official repo:
 
-    pacaur -S cava
+    pacman -S cava
 
 #### Ubuntu/Debian
 


### PR DESCRIPTION
It looks like Cava has been added to the [official Arch repositories](https://archlinux.org/packages/extra/x86_64/cava/), and the [AUR](https://aur.archlinux.org/packages/cava) link is no longer valid. I removed the AUR reference and updated the installation command to use pacman instead.