### PR TITLE
use malloc for alsa buffer_size

### DIFF
--- a/input/alsa.c
+++ b/input/alsa.c
@@ -70,7 +70,7 @@ void *input_alsa(void *data) {
     initialize_audio_parameters(&handle, audio, &frames);
     snd_pcm_get_params(handle, &buffer_size, &period_size);
 
-    unsigned char buf[buffer_size];
+    unsigned char *buf = malloc(buffer_size);
     frames = period_size / ((audio->format / 8) * CHANNELS_COUNT);
 
     signed char *buffer = malloc(period_size);
@@ -92,6 +92,7 @@ void *input_alsa(void *data) {
         write_to_cava_input_buffers(frames * CHANNELS_COUNT, buf, data);
     }
 
+    free(buf);
     free(buffer);
     snd_pcm_close(handle);
     return NULL;


### PR DESCRIPTION
ALSA is returning 512 KB for my driver, leading to a stack overflow. Addresses #654 