### PR TITLE
Fix various pipewire linking bugs

### DIFF
--- a/example_files/config
+++ b/example_files/config
@@ -70,7 +70,7 @@
 # (all pulseaudio sinks(outputs) have 'monitor' sources(inputs) associated with them).
 #
 # For pipewire 'source' will be the object name or object.serial of the device to capture from.
-# Both input and output devices are supported.
+# Both input and output devices are supported. To capture the monitor source of a sink node, append '.monitor' to the sink's object name.
 #
 # For alsa 'source' will be the capture device.
 # For fifo 'source' will be the path to fifo-file.

--- a/input/pipewire.c
+++ b/input/pipewire.c
@@ -91,10 +91,16 @@ void *input_pipewire(void *audiodata) {
     props = pw_properties_new(PW_KEY_MEDIA_TYPE, "Audio", PW_KEY_MEDIA_CATEGORY, "Capture",
                               PW_KEY_MEDIA_ROLE, "Music", NULL);
 
-    const char *source = data.cava_audio->source;
+    char *source = data.cava_audio->source;
+    size_t sourcelength = strlen(source);
+
+    if (8 <= sourcelength && !strcmp(source + sourcelength - 8, ".monitor")) {
+        source[sourcelength - 8] = '\0';
+        pw_properties_set(props, PW_KEY_STREAM_CAPTURE_SINK, "true");
+    }
     if (strcmp(source, "auto") == 0) {
         pw_properties_set(props, PW_KEY_STREAM_CAPTURE_SINK, "true");
-    } else {
+    } else if (strcmp(source, "auto_input") != 0) {
         pw_properties_set(props, PW_KEY_TARGET_OBJECT, source);
     }
     pw_properties_setf(props, PW_KEY_NODE_LATENCY, "%u/%u", nom, data.cava_audio->rate);


### PR DESCRIPTION
Handle `stream.capture.sink` correctly by means of pulseaudio syntax. Allows cava to connect to all nodes. Please refer to #661 for detail.

Fixes #661 #422 #557