### PR TITLE
Fix busy loop on Windows

### DIFF
--- a/input/winscap.c
+++ b/input/winscap.c
@@ -526,6 +526,7 @@ void input_winscap(void *data) {
 
                 pCapture->lpVtbl->ReleaseBuffer(pCapture, numFramesAvailable);
                 pCapture->lpVtbl->GetNextPacketSize(pCapture, &packetLength);
+                ResetEvent(hEvent);
             }
         }
         deviceChanged = FALSE;


### PR DESCRIPTION
While the `WaitForSingleObject()` function was utilized to wait for an event signal, the signal was never reset resulting in a busy loop.
Addresses #680 