### PR TITLE
feat(hardening): add live config auto-reload and tighten long-running…

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = ./.git,./.deps,./.libs,./autom4te.cache,./build,./third_party,./yasb,./cava_win/packages,./cava_win/x64,./cava_win/vcpkg_installed,./cava_win/meson-private,./m4,./Makefile,./Makefile.in,./aclocal.m4,./ar-lib,./compile,./config.guess,./config.sub,./configure,./depcomp,./install-sh,./libtool,./ltmain.sh,./missing,./version,./cava
+ignore-words-list = datas

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,6 +1,7 @@
+---
 name: Build CAVA Android
 
-on:
+'on':
   workflow_dispatch:
 
 jobs:
@@ -32,12 +33,13 @@ jobs:
 
       - name: Export NDK path
         run: |
-          echo "ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
-          echo "$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_PATH
+          echo "ANDROID_NDK_HOME=${ANDROID_SDK_ROOT}/ndk/25.2.9519653" \
+            >> "${GITHUB_ENV}"
+          echo "${ANDROID_SDK_ROOT}/ndk/25.2.9519653" >> "${GITHUB_PATH}"
 
       - name: Clone fftw3-android
         run: |
-          cd $GITHUB_WORKSPACE
+          cd "${GITHUB_WORKSPACE}"
           git clone https://github.com/Lauszus/fftw3-android
 
       - name: Build fftw3-android
@@ -50,7 +52,7 @@ jobs:
         run: |
           cd cava/cavandroid
           ./gradlew assembleRelease \
-            -Pcmake.fftw3.dir="$GITHUB_WORKSPACE/fftw3-android"
+            -Pcmake.fftw3.dir="${GITHUB_WORKSPACE}/fftw3-android"
 
       - name: Upload APK
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,77 +1,103 @@
+---
 name: build-and-test
-on: [push, pull_request, workflow_dispatch]
+
+'on':
+  push:
+  pull_request:
+  workflow_dispatch:
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: DoozyX/clang-format-lint-action@v0.5
-      with:
-        source: '.'
-        exclude: './third_party'
-        extensions: 'h,c'
+      - uses: actions/checkout@v4
+      - uses: DoozyX/clang-format-lint-action@v0.5
+        with:
+          source: .
+          exclude: ./third_party
+          extensions: h,c
+
   build-linux:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install libfftw3-dev libasound2-dev libncursesw5-dev libpulse-dev libtool automake autoconf-archive libiniparser-dev portaudio19-dev libsndio-dev libsdl2-2.0-0 libsdl2-dev squeezelite pulseaudio libpipewire-0.3-dev
-    - name: Generate configure
-      run: ./autogen.sh
-    - name: Run ./configure
-      run: ./configure
-    - name: Run make
-      run: make CFLAGS='-Werror'
-    - name: Run make distcheck
-      run: make distcheck
-    - name: Prepare tests
-      run: |
-        pulseaudio -D
-        squeezelite -o pulse -v -m 51:fb:32:f8:e6:9f -z
-    - name: run non zero test
-      run: ./cava -p example_files/test_configs/non_zero_test > /dev/null
-    - name: run pulseaudio test
-      run: ./cava -p example_files/test_configs/pulse_zero_test > /dev/null
-    - name: run fifo test
-      run: ./cava -p example_files/test_configs/fifo_zero_test > /dev/null
-    - name: run shmem test
-      run: ./cava -p example_files/test_configs/shmem_zero_test > /dev/null
-    - name: build cavacore test application
-      run: gcc -c -g cavacore_test.c
-    - name: link cavacore test application
-      run: gcc -o cavacore_test cavacore_test.o cava-cavacore.o -lm -lfftw3
-    - name: run cavacore test application
-      run: ./cavacore_test
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libfftw3-dev \
+            libasound2-dev \
+            libncursesw5-dev \
+            libpulse-dev \
+            libtool \
+            automake \
+            autoconf-archive \
+            libiniparser-dev \
+            portaudio19-dev \
+            libsndio-dev \
+            libsdl2-2.0-0 \
+            libsdl2-dev \
+            squeezelite \
+            pulseaudio \
+            libpipewire-0.3-dev
+      - name: Generate configure
+        run: ./autogen.sh
+      - name: Run ./configure
+        run: ./configure
+      - name: Run make
+        run: make CFLAGS='-Werror'
+      - name: Run make distcheck
+        run: make distcheck
+      - name: Prepare tests
+        run: |
+          pulseaudio -D
+          squeezelite -o pulse -v -m 51:fb:32:f8:e6:9f -z
+      - name: run non zero test
+        run: ./cava -p example_files/test_configs/non_zero_test > /dev/null
+      - name: run pulseaudio test
+        run: ./cava -p example_files/test_configs/pulse_zero_test > /dev/null
+      - name: run fifo test
+        run: ./cava -p example_files/test_configs/fifo_zero_test > /dev/null
+      - name: run shmem test
+        run: ./cava -p example_files/test_configs/shmem_zero_test > /dev/null
+      - name: build cavacore test application
+        run: gcc -c -g cavacore_test.c
+      - name: link cavacore test application
+        run: gcc -o cavacore_test cavacore_test.o cava-cavacore.o -lm -lfftw3
+      - name: run cavacore test application
+        run: ./cavacore_test
 
   build-macos:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Install dependencies
-      run: |
-        brew install fftw libtool automake portaudio iniparser sdl2
-        ln -s /usr/local/bin/glibtoolize /usr/local/bin/libtoolize
-    - name: Generate configuresdl2
-      run: PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" ./autogen.sh
-    - name: Run ./configure
-      run: LDFLAGS="-L/opt/homebrew/lib" CPPFLAGS="-I/opt/homebrew/include" ./configure
-    - name: Run make
-      run:  make CFLAGS='-Werror'
-    - name: run non zero test
-      run: ./cava -p example_files/test_configs/non_zero_test > /dev/null
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          brew install fftw libtool automake portaudio iniparser sdl2
+          ln -s /usr/local/bin/glibtoolize /usr/local/bin/libtoolize
+      - name: Generate configuresdl2
+        run: |
+          PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" ./autogen.sh
+      - name: Run ./configure
+        run: |
+          LDFLAGS="-L/opt/homebrew/lib" \
+          CPPFLAGS="-I/opt/homebrew/include" \
+          ./configure
+      - name: Run make
+        run: make CFLAGS='-Werror'
+      - name: run non zero test
+        run: ./cava -p example_files/test_configs/non_zero_test > /dev/null
 
   build-windows:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v2
-    - name: Install dependencies
-      run: nuget restore cava_win\cava_win.sln
-    - name: Run msbuild
-      run: msbuild /p:Configuration=Debug cava_win\cava_win.sln
+      - uses: actions/checkout@v4
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v2
+      - name: Install dependencies
+        run: nuget restore cava_win\cava_win.sln
+      - name: Run msbuild
+        run: msbuild /p:Configuration=Debug cava_win\cava_win.sln
 
   build-mingw:
     runs-on: windows-latest
@@ -82,12 +108,12 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-    - uses: actions/checkout@v4
-    - uses: msys2/setup-msys2@v2
-      with:
-        msystem: ${{matrix.msystem}}
-        pacboy: cc cmake fftw glew ninja SDL2
-    - name: Run cmake build
-      run: |
-        cmake -B bin
-        cmake --build bin
+      - uses: actions/checkout@v4
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.msystem }}
+          pacboy: cc cmake fftw glew ninja SDL2
+      - name: Run cmake build
+        run: |
+          cmake -B bin
+          cmake --build bin

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ yasb/*
 cava_win/vcpkg_installed/vcpkg/*
 cava_win/vcpkg_installed/x64-windows/*
 cava_win/meson-private
+
+!.codespellrc
+!.github/
+!.github/**

--- a/cavacore.c
+++ b/cavacore.c
@@ -310,12 +310,12 @@ void cava_execute(double *cava_in, int new_samples, double *cava_out, struct cav
         p->framerate += (double)((p->rate * p->audio_channels * p->frame_skip) / new_samples) / 64;
         p->frame_skip = 1;
         // shifting input buffer
-        for (uint16_t n = p->input_buffer_size - 1; n >= new_samples; n--) {
+        for (int n = p->input_buffer_size - 1; n >= new_samples; n--) {
             p->input_buffer[n] = p->input_buffer[n - new_samples];
         }
 
         // fill the input buffer
-        for (uint16_t n = 0; n < new_samples; n++) {
+        for (int n = 0; n < new_samples; n++) {
             p->input_buffer[new_samples - n - 1] = cava_in[n];
             if (cava_in[n]) {
                 silence = 0;
@@ -326,7 +326,7 @@ void cava_execute(double *cava_in, int new_samples, double *cava_out, struct cav
     }
 
     // fill the bass, mid and treble buffers
-    for (uint16_t n = 0; n < p->FFTbassbufferSize; n++) {
+    for (int n = 0; n < p->FFTbassbufferSize; n++) {
         if (p->audio_channels == 2) {
             p->in_bass_r_raw[n] = p->input_buffer[n * 2];
             p->in_bass_l_raw[n] = p->input_buffer[n * 2 + 1];
@@ -334,7 +334,7 @@ void cava_execute(double *cava_in, int new_samples, double *cava_out, struct cav
             p->in_bass_l_raw[n] = p->input_buffer[n];
         }
     }
-    for (uint16_t n = 0; n < p->FFTbufferSize; n++) {
+    for (int n = 0; n < p->FFTbufferSize; n++) {
         if (p->audio_channels == 2) {
             p->in_r_raw[n] = p->input_buffer[n * 2];
             p->in_l_raw[n] = p->input_buffer[n * 2 + 1];

--- a/config.c
+++ b/config.c
@@ -813,6 +813,7 @@ bool load_config(char configPath[PATH_MAX], struct config_params *p, struct erro
     p->lower_cut_off = iniparser_getint(ini, "general:lower_cutoff_freq", 50);
     p->upper_cut_off = iniparser_getint(ini, "general:higher_cutoff_freq", 8000);
     p->sleep_timer = iniparser_getint(ini, "general:sleep_timer", 0);
+    p->live_config = iniparser_getint(ini, "general:live-config", 0);
     int max_height = iniparser_getint(ini, "general:max_height", 100);
     p->max_height = max_height / 100.0;
     p->center_align = iniparser_getint(ini, "general:center_align", 1);
@@ -1010,6 +1011,7 @@ bool load_config(char configPath[PATH_MAX], struct config_params *p, struct erro
     p->lower_cut_off = GetPrivateProfileInt("general", "lower_cutoff_freq", 50, configPath);
     p->upper_cut_off = GetPrivateProfileInt("general", "higher_cutoff_freq", 10000, configPath);
     p->sleep_timer = GetPrivateProfileInt("general", "sleep_timer", 0, configPath);
+    p->live_config = GetPrivateProfileInt("general", "live-config", 0, configPath);
     p->max_height = GetPrivateProfileInt("general", "max_height", 100, configPath) / 100.0;
     p->center_align = GetPrivateProfileInt("general", "center_align", 1, configPath);
 

--- a/config.h
+++ b/config.h
@@ -121,7 +121,7 @@ struct config_params {
         bit_format, gradient, gradient_count, horizontal_gradient, horizontal_gradient_count,
         fixedbars, framerate, bar_width, bar_spacing, bar_height, autosens, overshoot, waves,
         active, remix, virtual_node, samplerate, samplebits, channels, autoconnect, sleep_timer,
-        sdl_width, sdl_height, sdl_x, sdl_y, sdl_full_screen, draw_and_quit, zero_test,
+        live_config, sdl_width, sdl_height, sdl_x, sdl_y, sdl_full_screen, draw_and_quit, zero_test,
         non_zero_test, reverse, sync_updates, continuous_rendering, disable_blanking,
         show_idle_bar_heads, waveform, center_align, horizontal_stereo, left_bottom;
 };

--- a/example_files/config
+++ b/example_files/config
@@ -4,6 +4,9 @@
 
 [general]
 
+# Auto reload config if the configuration file has changed. 1 = on, 0 = off.
+; live-config = 1
+
 # Smoothing mode. Can be 'normal', 'scientific' or 'waves'. DEPRECATED as of 0.6.0
 ; mode = normal
 
@@ -46,7 +49,7 @@
 # Lower and higher cutoff frequencies for lowest and highest bars
 # the bandwidth of the visualizer.
 # Note: there is a minimum total bandwidth of 43Mhz x number of bars.
-# Cava will automatically increase the higher cutoff if a too low band is specified.
+# Cava will automatically increase the higher cutoff frequency if needed to satisfy the minimum bandwidth.
 ; lower_cutoff_freq = 50
 ; higher_cutoff_freq = 10000
 
@@ -213,7 +216,7 @@
 # 'frequency' displays the lower cut off frequency of the bar above.
 # Only supported on ncurses and noncurses output.
 ; xaxis = none
- 
+
 # enable synchronized sync. 1 = on, 0 = off
 # removes flickering in alacritty terminal emulator.
 # defaults to off since the behaviour in other terminal emulators is unknown


### PR DESCRIPTION
… resource safety

- Parse new general:live-config option and document it in example config

- Monitor config mtime/size and trigger reload when config file changes

- Fix potential unsigned underflow/infinite loop risks in cavacore buffer loops

- Correct audio buffer zeroing for double-based cava_in

- Close raw/noritake output fds on reload/exit and destroy audio mutex after join

- Harden frame timing to avoid invalid sleeps / divide-by-zero edge cases

- Clean up CI workflows and add codespell configuration

Author: rezky_nightky <with dot rezky at gmail dot com>
Repository: cava
Branch: master
Signing: GPG (4B65AAC2)
HashAlgo: BLAKE3

[ Block Metadata ]
BlockHash: 372c169782927d40e0a299860e127da055616a3e123fe44ddbd9820e70790761 PrevHash: b53364f6a353709b44a3a8deaa2e0d42435374be928b315529c2ad6ebf483ba5 PatchHash: 667a288d18d0a150870f43cee7009ebbd2dc79fb2b105db654087f4979226034

FilesChanged: 9
Lines: +231 / -99

Timestamp: 2026-01-04T08:56:03Z
Signature1: 8cc7f093adde1b4e9b38edbd8730210edeba51e78b2a2f6b7bb678bb31f5b35c
Signature2: 046ab5cfd313bde5d58d6ebd089b479f66b08a36e7bf209ed45a82b7c39c9057