### PR TITLE
output/shaders: add Orion circle shaders (static + rotating)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,6 +21,8 @@ EXTRA_DIST = \
     output/shaders/winamp_line_style_spectrum.frag \
     output/shaders/spectrogram.frag \
     output/shaders/eye_of_phi.frag \
+    output/shaders/orion_circle.frag \
+    output/shaders/orion_circle_rotate.frag \
     output/themes/solarized_dark \
     output/themes/tricolor \
     example_files/config \

--- a/cava_win/cava/cava.rc
+++ b/cava_win/cava/cava.rc
@@ -6,6 +6,8 @@
 #define IDR_SPECTROGRAM_SHADER 105
 #define IDR_WINAMP_LINE_STYLE_SPECTRUM_SHADER 106
 #define IDR_EYE_OF_PHI_SHADER 107
+#define IDR_ORION_CIRCLE_SHADER 108
+#define IDR_ORION_CIRCLE_ROTATE_SHADER 109
 
 #define IDR_SOLARIZED_DARK_THEME 501
 #define IDR_TRICOLOR_THEME 502
@@ -18,6 +20,8 @@ IDR_PASS_THROUGH_SHADER TEXTFILE "../../output/shaders/pass_through.vert"
 IDR_SPECTROGRAM_SHADER TEXTFILE "../../output/shaders/spectrogram.frag"
 IDR_WINAMP_LINE_STYLE_SPECTRUM_SHADER TEXTFILE "../../output/shaders/winamp_line_style_spectrum.frag"
 IDR_EYE_OF_PHI_SHADER TEXTFILE "../../output/shaders/eye_of_phi.frag"
+IDR_ORION_CIRCLE_SHADER TEXTFILE "../../output/shaders/orion_circle.frag"
+IDR_ORION_CIRCLE_ROTATE_SHADER TEXTFILE "../../output/shaders/orion_circle_rotate.frag"
 
 IDR_SOLARIZED_DARK_THEME TEXTFILE "../../output/themes/solarized_dark"
 IDR_TRICOLOR_THEME TEXTFILE "../../output/themes/tricolor"

--- a/config.c
+++ b/config.c
@@ -18,7 +18,7 @@
 
 #include <sys/stat.h>
 
-#define NUMBER_OF_SHADERS 6
+#define NUMBER_OF_SHADERS 8
 
 #define NUMBER_OF_THEMES 2
 
@@ -33,6 +33,8 @@
 #define IDR_SPECTROGRAM_SHADER 105
 #define IDR_WINAMP_LINE_STYLE_SPECTRUM_SHADER 106
 #define IDR_EYE_OF_PHI_SHADER 107
+#define IDR_ORION_CIRCLE_SHADER 108
+#define IDR_ORION_CIRCLE_ROTATE_SHADER 109
 
 #define IDR_SOLARIZED_DARK_THEME 501
 #define IDR_TRICOLOR_THEME 502
@@ -58,7 +60,8 @@ static void LoadFileInResource(int name, int type, DWORD *size, const char **dat
 int default_shader_data[NUMBER_OF_SHADERS] = {
     IDR_NORTHERN_LIGHTS_SHADER, IDR_PASS_THROUGH_SHADER,
     IDR_BAR_SPECTRUM_SHADER,    IDR_WINAMP_LINE_STYLE_SPECTRUM_SHADER,
-    IDR_SPECTROGRAM_SHADER,     IDR_EYE_OF_PHI_SHADER};
+    IDR_SPECTROGRAM_SHADER,     IDR_EYE_OF_PHI_SHADER,
+    IDR_ORION_CIRCLE_SHADER,    IDR_ORION_CIRCLE_ROTATE_SHADER};
 
 int default_theme_data[NUMBER_OF_THEMES] = {IDR_SOLARIZED_DARK_THEME, IDR_TRICOLOR_THEME};
 #else
@@ -73,6 +76,8 @@ INCTXT(northern_lightsfrag, "output/shaders/northern_lights.frag");
 INCTXT(winamp_line_style_spectrum, "output/shaders/winamp_line_style_spectrum.frag");
 INCTXT(spectrogram, "output/shaders/spectrogram.frag");
 INCTXT(eye_of_phi, "output/shaders/eye_of_phi.frag");
+INCTXT(orion_circle, "output/shaders/orion_circle.frag");
+INCTXT(orion_circle_rotate, "output/shaders/orion_circle_rotate.frag");
 
 INCTXT(pass_throughvert, "output/shaders/pass_through.vert");
 
@@ -82,7 +87,8 @@ INCTXT(tricolor, "output/themes/tricolor");
 // INCTXT will create a char g<name>Data
 const char *default_shader_data[NUMBER_OF_SHADERS] = {
     gnorthern_lightsfragData,        gpass_throughvertData, gbar_spectrumData,
-    gwinamp_line_style_spectrumData, gspectrogramData,      geye_of_phiData};
+    gwinamp_line_style_spectrumData, gspectrogramData,      geye_of_phiData,
+    gorion_circleData,               gorion_circle_rotateData};
 
 const char *default_theme_data[NUMBER_OF_THEMES] = {gsolarized_darkData, gtricolorData};
 #endif // _WIN32
@@ -91,7 +97,8 @@ const char *default_theme_data[NUMBER_OF_THEMES] = {gsolarized_darkData, gtricol
 const char *default_shader_name[NUMBER_OF_SHADERS] = {
     "northern_lights.frag", "pass_through.vert",
     "bar_spectrum.frag",    "winamp_line_style_spectrum.frag",
-    "spectrogram.frag",     "eye_of_phi.frag"};
+    "spectrogram.frag",     "eye_of_phi.frag",
+    "orion_circle.frag",    "orion_circle_rotate.frag"};
 const char *default_theme_name[NUMBER_OF_THEMES] = {"solarized_dark", "tricolor"};
 
 double smoothDef[5] = {1, 1, 1, 1, 1};

--- a/output/shaders/orion_circle.frag
+++ b/output/shaders/orion_circle.frag
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+// Author: rezky_nightky <with.rezky@gmail.com>
+// Static Orion (non-rotating)
+#version 330
+
+in vec2 fragCoord;
+out vec4 fragColor;
+
+uniform float bars[512];
+
+uniform int bars_count;
+uniform int bar_width;
+uniform int bar_spacing;
+
+uniform vec3 u_resolution;
+
+uniform vec3 bg_color;
+uniform vec3 fg_color;
+
+uniform int gradient_count;
+uniform vec3 gradient_colors[8];
+
+uniform sampler2D inputTexture;
+
+vec3 normalize_C(float y, vec3 col_1, vec3 col_2, float y_min, float y_max) {
+    float yr = (y - y_min) / (y_max - y_min);
+    return col_1 * (1.0 - yr) + col_2 * yr;
+}
+
+void main() {
+    vec2 p = fragCoord - vec2(0.5);
+    p.x *= u_resolution.x / u_resolution.y;
+
+    float base_radius = 0.35;
+    float max_len = 0.15;
+    float pad = 2.0 / u_resolution.y;
+    float min_r = max(base_radius - pad, 0.0);
+    float max_r = base_radius + max_len + pad;
+
+    float r2 = dot(p, p);
+    if (r2 < min_r * min_r || r2 > max_r * max_r) {
+        fragColor = vec4(bg_color, 1.0);
+        return;
+    }
+
+    float r = sqrt(r2);
+
+    float theta = atan(p.y, p.x);
+
+    float pi = radians(180.0);
+    float tau = pi * 2.0;
+
+    float a = (theta + pi) / tau;
+    a = fract(a);
+
+    if (bars_count <= 0) {
+        fragColor = vec4(bg_color, 1.0);
+        return;
+    }
+
+    float cell = a * float(bars_count);
+    int bar = int(floor(cell));
+    bar = clamp(bar, 0, bars_count - 1);
+    float f = fract(cell);
+
+    float fill = float(bar_width) / max(float(bar_width + bar_spacing), 1.0);
+    float angular = abs(f - 0.5);
+    float df = fwidth(cell);
+    float angular_alpha = 1.0 - smoothstep(fill * 0.5 - df, fill * 0.5 + df, angular);
+
+    float y = clamp(bars[bar], 0.0, 1.0);
+
+    float amp = y * (1.0 + 0.8 * (1.0 - y));
+
+    float min_len = 1.0 / u_resolution.y;
+    float len = max(amp * max_len, min_len);
+    float act = smoothstep(0.0, min_len / max_len, amp);
+
+    float dr = fwidth(r);
+    float inner = smoothstep(base_radius - dr, base_radius + dr, r);
+    float outer = 1.0 - smoothstep(base_radius + len - dr, base_radius + len + dr, r);
+    float radial_alpha = inner * outer * act;
+
+    float alpha = angular_alpha * radial_alpha;
+
+    vec3 col;
+    if (gradient_count == 0) {
+        col = fg_color;
+    } else {
+        if (gradient_count == 1) {
+            col = gradient_colors[0];
+        } else {
+            int color = int(floor((gradient_count - 1) * amp));
+            color = clamp(color, 0, gradient_count - 2);
+            float y_min = float(color) / (gradient_count - 1.0);
+            float y_max = float(color + 1) / (gradient_count - 1.0);
+            col =
+                normalize_C(amp, gradient_colors[color], gradient_colors[color + 1], y_min, y_max);
+        }
+    }
+
+    fragColor = vec4(mix(bg_color, col, alpha), 1.0);
+}

--- a/output/shaders/orion_circle_rotate.frag
+++ b/output/shaders/orion_circle_rotate.frag
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT
+// Author: rezky_nightky <with.rezky@gmail.com>
+#version 330
+
+in vec2 fragCoord;
+out vec4 fragColor;
+
+uniform float bars[512];
+
+uniform int bars_count;
+uniform int bar_width;
+uniform int bar_spacing;
+
+uniform vec3 u_resolution;
+
+uniform vec3 bg_color;
+uniform vec3 fg_color;
+
+uniform int gradient_count;
+uniform vec3 gradient_colors[8];
+
+uniform float shader_time;
+
+uniform sampler2D inputTexture;
+
+vec3 normalize_C(float y, vec3 col_1, vec3 col_2, float y_min, float y_max) {
+    float yr = (y - y_min) / (y_max - y_min);
+    return col_1 * (1.0 - yr) + col_2 * yr;
+}
+
+void main() {
+    vec2 p = fragCoord - vec2(0.5);
+    p.x *= u_resolution.x / u_resolution.y;
+
+    float base_radius = 0.35;
+    float max_len = 0.15;
+    float pad = 2.0 / u_resolution.y;
+    float min_r = max(base_radius - pad, 0.0);
+    float max_r = base_radius + max_len + pad;
+
+    float r2 = dot(p, p);
+    if (r2 < min_r * min_r || r2 > max_r * max_r) {
+        fragColor = vec4(bg_color, 1.0);
+        return;
+    }
+
+    float r = sqrt(r2);
+
+    float theta = atan(p.y, p.x);
+
+    float pi = radians(180.0);
+    float tau = pi * 2.0;
+
+    float a = (theta + pi) / tau;
+    a = fract(a);
+
+    if (bars_count <= 0) {
+        fragColor = vec4(bg_color, 1.0);
+        return;
+    }
+
+    float speed = 0.25;
+    float sweep_pos = fract(shader_time * speed);
+    float da = abs(a - sweep_pos);
+    da = min(da, 1.0 - da);
+    float sweep = 1.0 - smoothstep(0.0, 0.08 + fwidth(a), da);
+
+    float cell = a * float(bars_count);
+    int bar = int(floor(cell));
+    bar = clamp(bar, 0, bars_count - 1);
+    float f = fract(cell);
+
+    float fill = float(bar_width) / max(float(bar_width + bar_spacing), 1.0);
+    float angular = abs(f - 0.5);
+    float df = fwidth(cell);
+    float angular_alpha = 1.0 - smoothstep(fill * 0.5 - df, fill * 0.5 + df, angular);
+
+    float y = clamp(bars[bar], 0.0, 1.0);
+
+    float amp = y * (1.0 + 0.8 * (1.0 - y));
+
+    float min_len = 1.0 / u_resolution.y;
+    float len = max(amp * max_len, min_len);
+    float act = smoothstep(0.0, min_len / max_len, amp);
+
+    float dr = fwidth(r);
+    float inner = smoothstep(base_radius - dr, base_radius + dr, r);
+    float outer = 1.0 - smoothstep(base_radius + len - dr, base_radius + len + dr, r);
+    float radial_alpha = inner * outer * act;
+
+    float alpha = angular_alpha * radial_alpha;
+
+    vec3 col;
+    if (gradient_count == 0) {
+        col = fg_color;
+    } else {
+        if (gradient_count == 1) {
+            col = gradient_colors[0];
+        } else {
+            int color = int(floor((gradient_count - 1) * amp));
+            color = clamp(color, 0, gradient_count - 2);
+            float y_min = float(color) / (gradient_count - 1.0);
+            float y_max = float(color + 1) / (gradient_count - 1.0);
+            col = normalize_C(amp, gradient_colors[color], gradient_colors[color + 1], y_min, y_max);
+        }
+    }
+
+    col = min(col * (1.0 + 0.35 * sweep * alpha), vec3(1.0));
+
+    fragColor = vec4(mix(bg_color, col, alpha), 1.0);
+}


### PR DESCRIPTION
Refs https://github.com/karlstav/cava/issues/726

<img width="1052" height="608" alt="orion-demo" src="https://github.com/user-attachments/assets/43a5c67a-8fa7-4c82-8b00-abb835875139" />

Adds two new built-in SDL_GLSL fragment shaders:
- output/shaders/orion_circle.frag (static)
- output/shaders/orion_circle_rotate.frag (animated via shader_time)

Also registers them as built-in shaders:
- Linux: add INCTXT entries and extend default shader arrays in config.c
- Windows: add resource IDs and embed shader files in cava_win/cava/cava.rc
- Dist: add shader files to EXTRA_DIST in Makefile.am

Testing:
- Build: make -j
- Runtime: run cava with output method sdl_glsl and select the new shader(s) from ~/.config/cava/shaders