### PR TITLE
fix(win-installer): update post-installation instructions and add PATH variable modification

### DIFF
--- a/cava_win/postsetupinfo.txt
+++ b/cava_win/postsetupinfo.txt
@@ -1,5 +1,8 @@
 config file for cava is created in "%USERPROFILE%\.config\cava" upon first launch
 
+The installation directory has been added to your PATH environment variable.
+You may need to restart your terminal or log out and log back in for the 'cava' command to work.
+
 you need to install Visual C++ redistributable if you do not already have it:
 
 https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist

--- a/cava_win/setup.iss
+++ b/cava_win/setup.iss
@@ -46,6 +46,10 @@ Source: "packages\sdl2.redist.2.0.5\build\native\bin\x64\dynamic\SDL2.dll"; Dest
 [Icons]
 Name: "{group}\cava"; Filename: "{app}\cava.exe"
 
+[Registry]
+; Add installation directory to user PATH environment variable
+Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}"
+
 [Run]
 Filename: "{app}\cava.exe"; Description: "{cm:LaunchProgram,cava}"; Flags: nowait postinstall skipifsilent
 


### PR DESCRIPTION
- Added instructions for the user regarding the installation directory being added to the PATH environment variable.
- Included a note about the need to restart the terminal or log out for changes to take effect.
- Updated the installer script to modify the user's PATH environment variable to include the installation directory.