### PR TITLE
feat(build): add WiX installer support for Windows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -97,7 +97,23 @@ jobs:
       - name: Install dependencies
         run: nuget restore cava_win\cava_win.sln
       - name: Run msbuild
-        run: msbuild /p:Configuration=Debug cava_win\cava_win.sln
+        run: msbuild /p:Configuration=Release cava_win\cava_win.sln
+      - name: Install WiX Toolset
+        run: dotnet tool install --global wix
+      - name: Install WiX extensions
+        run: |
+          wix extension add WixToolset.UI.wixext
+          wix extension add WixToolset.Util.wixext
+      - name: Build MSI installer
+        run: |
+          $versionLine = Select-String -Path cava_win\setup.iss -Pattern '^AppVersion=' | Select-Object -First 1
+          $cavaVersion = $versionLine.Line.Split('=')[1].Trim()
+          wix build -arch x64 cava_win\cava.wxs -d CavaVersion=$cavaVersion -ext WixToolset.UI.wixext -ext WixToolset.Util.wixext -o cava_win\cava_win_x64_install.msi
+      - name: Upload MSI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cava-msi
+          path: cava_win\cava_win_x64_install.msi
 
   build-mingw:
     runs-on: windows-latest

--- a/cava_win/cava.wxs
+++ b/cava_win/cava.wxs
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+  <Package
+    Name="cava"
+    Version="$(var.CavaVersion)"
+    Manufacturer="karlstav"
+    UpgradeCode="{B8D2AE6A-71E4-42E3-8C9F-33245C657272}"
+    InstallerVersion="500"
+    Scope="perUser"
+    Compressed="yes">
+    <MajorUpgrade DowngradeErrorMessage="A newer version of cava is already installed." />
+    <MediaTemplate EmbedCab="yes" />
+
+    <ui:WixUI Id="WixUI_InstallDir" InstallDirectory="INSTALLFOLDER" />
+    <WixVariable Id="WixUILicenseRtf" Value="cava_win\license.rtf" />
+    <Property Id="ARPURLINFOABOUT" Value="https://github.com/karlstav/cava" />
+    <Property Id="ARPURLUPDATEINFO" Value="https://github.com/karlstav/cava" />
+    <Property Id="ARPSUPPORTURL" Value="https://github.com/karlstav/cava" />
+
+    <StandardDirectory Id="LocalAppDataFolder">
+      <Directory Id="INSTALLFOLDER" Name="cava">
+        <Component Id="cmpCavaExe" Guid="*">
+          <File Id="filCavaExe" Source="cava_win\cava\x64\Release\cava.exe" KeyPath="yes" />
+        </Component>
+        <Component Id="cmpFftw" Guid="*">
+          <File Id="filFftw" Source="cava_win\packages\fftw_339.3.3.9.202108273\lib\native\fftw-release\bin\fftw3.dll" KeyPath="yes" />
+        </Component>
+        <Component Id="cmpGlew" Guid="*">
+          <File Id="filGlew" Source="cava_win\packages\glew.redist.1.9.0.1\build\native\bin\v110\x64\Release\dynamic\glew.dll" KeyPath="yes" />
+        </Component>
+        <Component Id="cmpPthread" Guid="*">
+          <File Id="filPthread" Source="cava_win\packages\pthreads.redist.2.9.1.4\build\native\bin\v110\x64\Release\dynamic\cdecl\libpthread.dll" KeyPath="yes" />
+        </Component>
+        <Component Id="cmpSDL2" Guid="*">
+          <File Id="filSDL2" Source="cava_win\packages\sdl2.redist.2.0.5\build\native\bin\x64\dynamic\SDL2.dll" KeyPath="yes" />
+        </Component>
+        <Component Id="cmpEnv" Guid="{2A6E1E10-36A0-4B0A-8B72-5C9B4A2E67C5}">
+          <Environment Id="envPath" Name="PATH" Value="[INSTALLFOLDER]" Action="set" System="no" Part="last" Permanent="no" />
+        </Component>
+      </Directory>
+    </StandardDirectory>
+    <Feature Id="ProductFeature" Title="cava" Level="1">
+      <ComponentRef Id="cmpCavaExe" />
+      <ComponentRef Id="cmpFftw" />
+      <ComponentRef Id="cmpGlew" />
+      <ComponentRef Id="cmpPthread" />
+      <ComponentRef Id="cmpSDL2" />
+      <ComponentRef Id="cmpEnv" />
+    </Feature>
+  </Package>
+</Wix>

--- a/cava_win/license.rtf
+++ b/cava_win/license.rtf
@@ -1,0 +1,23 @@
+{\rtf1\ansi\deff0
+{\fonttbl{\f0 Calibri;}}
+\fs20
+Copyright (c) 2015 Karl Stavestrand <karl@stavestrand.no>\par
+\par
+Permission is hereby granted, free of charge, to any person obtaining a copy\par
+of this software and associated documentation files (the "Software"), to deal\par
+in the Software without restriction, including without limitation the rights\par
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\par
+copies of the Software, and to permit persons to whom the Software is\par
+furnished to do so, subject to the following conditions:\par
+\par
+The above copyright notice and this permission notice shall be included in all\par
+copies or substantial portions of the Software.\par
+\par
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\par
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\par
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\par
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\par
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\par
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\par
+SOFTWARE.\par
+}


### PR DESCRIPTION
- Install WiX Toolset and extensions for MSI packaging.
- Create MSI installer for cava with necessary components.
- Upload MSI artifact for distribution.

There is a little difference between this MSI installer and the Inno. I decided not to add a shortcut because you don’t have an icon and probably don’t need, since Cava is a CLI tool, but if you want, we can also include it in the installer.

The license file has been converted from your current one to RTF format. If you need changes, you can modify it.

The MSI installer does not require admin privileges to install because it is installed per user.

The PATH environment variable is added automatically on install and uninstall.

The artifact is included in the workflow build.

What we can do in the future? This MSI is ready for Winget, so you can create a package there once. We can also create a workflow later to update it automatically. The MSI reads the version dynamically, so you don’t need to change anything regarding the version or upgrade code.


https://github.com/user-attachments/assets/49c01174-99a8-4aa0-9e32-d1b7fe2304ef


