### PR TITLE
Replace AX_CHECK_GL with manual detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -317,20 +317,37 @@ AC_CHECK_LIB(SDL2,SDL_Init, have_sdl=yes, have_sdl=no)
           [do not include support for output with sdl_glsl])
       )
       AS_IF([test "x$enable_output_sdl_glsl" != "xno"], [
-             m4_ifdef([AX_CHECK_GL], [
-                       AX_CHECK_GL(have_opengl=yes, have_opengl=no)
-                       ], [
-                           AC_MSG_NOTICE([You need to install the autoconf archives to check for opengl. Remember to re-run autogen.sh.])
-                           have_opengl=no
-                           ])
-      if [[ $have_opengl = "yes" ]] ; then
-        LIBS="$LIBS $GL_LIBS"
-        CPPFLAGS="$CPPFLAGS -DSDL_GLSL $GL_CFLAGS"
-      fi
+        have_opengl=no
+        GL_LIBS=""
+        GL_CFLAGS=""
+        AC_MSG_CHECKING([for OpenGL])
 
-      if [[ $have_opengl = "no" ]] ; then
-        AC_MSG_NOTICE([INFO: building without sdl_glsl (opengl) support])
-      fi
+        case $host_os in
+          darwin*)
+            AC_CHECK_HEADER([OpenGL/gl.h],
+              [GL_LIBS="-framework OpenGL"
+               have_opengl=yes],
+              [have_opengl=no])
+            ;;
+          *)
+            AC_CHECK_HEADER([GL/gl.h],
+              [AC_SEARCH_LIBS([glBegin], [GL],
+                [have_opengl=yes
+                 AS_IF([test "x$ac_cv_search_glBegin" != "xnone required"],
+                       [GL_LIBS="$ac_cv_search_glBegin"])],
+                [have_opengl=no])],
+              [have_opengl=no])
+            ;;
+        esac
+
+        if test "x$have_opengl" = "xyes"; then
+          AC_MSG_RESULT([yes])
+          LIBS="$LIBS $GL_LIBS"
+          CPPFLAGS="$CPPFLAGS -DSDL_GLSL $GL_CFLAGS"
+        else
+          AC_MSG_RESULT([no])
+          AC_MSG_NOTICE([INFO: building without sdl_glsl (opengl) support])
+        fi
       ],
         [have_opengl=no]
       )


### PR DESCRIPTION
This fixes the issue on arch linux #594, and likely for any distro that is running autoconf-archive >= 2024.10.16 where cava cannot be built with an up-to-date autoconf-archive as there is a broken macro. This replaces the currently broken AC_CHECK_GL macro, with a manual check for opengl. I was initially planning on waiting for an update to autoconf-archive, but it has been over a year, and there is still not a proper fix to this broken macro.