### PR TITLE
Add CoreAudio tap permission handling

### DIFF
--- a/input/coreaudio_tap.m
+++ b/input/coreaudio_tap.m
@@ -1,4 +1,3 @@
-#include <CoreFoundation/CFBase.h>
 #import <Foundation/Foundation.h>
 
 #include <CoreAudio/AudioHardware.h>
@@ -81,27 +80,6 @@ static bool source_is(const char *source, const char *value) {
 }
 
 int coreaudio_tap_source_enabled(const char *source) {
-    void* TCC = dlopen("/System/Library/PrivateFrameworks/TCC.framework/Versions/A/TCC", RTLD_NOW);
-    if (TCC == NULL) {
-        fprintf(stderr, "ERROR: Could not open TCC.framework");
-        exit(EXIT_FAILURE);
-    }
-    int (*TCCAccessPreflight)(CFStringRef, CFDictionaryRef) = dlsym(TCC, "TCCAccessPreflight");
-    if (TCCAccessPreflight == NULL) {
-        fprintf(stderr, "ERROR: Could not get function TCCAccessPreflight");
-        exit(EXIT_FAILURE);
-    }
-    dlclose(TCC);
-
-    CFStringRef kTCCServiceAudioCapture = cfstring_from_cstr("kTCCServiceAudioCapture");
-
-    if (TCCAccessPreflight(kTCCServiceAudioCapture, NULL) != 0) {
-        fprintf(stderr, "ERROR: AudioTap permissions missing! requesting...\n");
-        fprintf(stderr, "       Please add \"%s\" to the \"System Audio Recording Only\" section.\n", getenv("TERM_PROGRAM"));
-        system("/usr/bin/open x-apple.systempreferences:com.apple.settings.PrivacySecurity?Privacy_ScreenCapture");
-        exit(EXIT_FAILURE);
-    }
-
     if (source == NULL) {
         return 0;
     }
@@ -112,6 +90,30 @@ int coreaudio_tap_source_enabled(const char *source) {
 }
 
 static CATapDescription *build_tap_description(const char *source) {
+    void* TCC = dlopen("/System/Library/PrivateFrameworks/TCC.framework/Versions/A/TCC", RTLD_NOW);
+    if (TCC == NULL) {
+        fprintf(stderr, "Warning: Unable to load TCC.framework! Cannot check permissions...");
+    }
+    int (*TCCAccessPreflight)(CFStringRef, CFDictionaryRef) = dlsym(TCC, "TCCAccessPreflight");
+    if (TCCAccessPreflight == NULL) {
+        fprintf(stderr, "Warning: Could not get function TCCAccessPreflight! Cannot check permissions...");
+    }
+    dlclose(TCC);
+
+    CFStringRef kTCCServiceAudioCapture = cfstring_from_cstr("kTCCServiceAudioCapture");
+
+    if (TCCAccessPreflight != NULL && TCCAccessPreflight(kTCCServiceAudioCapture, NULL) != 0) {
+        fprintf(stderr, "ERROR: AudioTap permissions missing! requesting...\n");
+        char* term = getenv("TERM_PROGRAM");
+        if (term == NULL) {
+          fprintf(stderr, "       Please add your terminal emulator to the \"System Audio Recording Only\" section.\n");
+        } else {
+          fprintf(stderr, "       Please add \"%s\" to the \"System Audio Recording Only\" section.\n", term);
+        }
+        system("/usr/bin/open x-apple.systempreferences:com.apple.settings.PrivacySecurity?Privacy_ScreenCapture");
+        exit(EXIT_FAILURE);
+    }
+
     NSArray<NSNumber *> *excluded = @[];
 
     if (source_is(source, "tap_mono") || source_is(source, "tap_system_mono")) {

--- a/input/coreaudio_tap.m
+++ b/input/coreaudio_tap.m
@@ -83,23 +83,23 @@ static bool source_is(const char *source, const char *value) {
 int coreaudio_tap_source_enabled(const char *source) {
     void* TCC = dlopen("/System/Library/PrivateFrameworks/TCC.framework/Versions/A/TCC", RTLD_NOW);
     if (TCC == NULL) {
-      fprintf(stderr, "ERROR: Could not open TCC.framework");
-      exit(EXIT_FAILURE);
+        fprintf(stderr, "ERROR: Could not open TCC.framework");
+        exit(EXIT_FAILURE);
     }
     int (*TCCAccessPreflight)(CFStringRef, CFDictionaryRef) = dlsym(TCC, "TCCAccessPreflight");
     if (TCCAccessPreflight == NULL) {
-      fprintf(stderr, "ERROR: Could not get function TCCAccessPreflight");
-      exit(EXIT_FAILURE);
+        fprintf(stderr, "ERROR: Could not get function TCCAccessPreflight");
+        exit(EXIT_FAILURE);
     }
     dlclose(TCC);
 
     CFStringRef kTCCServiceAudioCapture = cfstring_from_cstr("kTCCServiceAudioCapture");
 
     if (TCCAccessPreflight(kTCCServiceAudioCapture, NULL) != 0) {
-      fprintf(stderr, "ERROR: AudioTap permissions missing! requesting...\n");
-      fprintf(stderr, "       Please add \"%s\" to the \"System Audio Recording Only\" section.\n", getenv("TERM_PROGRAM"));
-      system("/usr/bin/open x-apple.systempreferences:com.apple.settings.PrivacySecurity?Privacy_ScreenCapture");
-      exit(EXIT_FAILURE);
+        fprintf(stderr, "ERROR: AudioTap permissions missing! requesting...\n");
+        fprintf(stderr, "       Please add \"%s\" to the \"System Audio Recording Only\" section.\n", getenv("TERM_PROGRAM"));
+        system("/usr/bin/open x-apple.systempreferences:com.apple.settings.PrivacySecurity?Privacy_ScreenCapture");
+        exit(EXIT_FAILURE);
     }
 
     if (source == NULL) {

--- a/input/coreaudio_tap.m
+++ b/input/coreaudio_tap.m
@@ -82,7 +82,15 @@ static bool source_is(const char *source, const char *value) {
 
 int coreaudio_tap_source_enabled(const char *source) {
     void* TCC = dlopen("/System/Library/PrivateFrameworks/TCC.framework/Versions/A/TCC", RTLD_NOW);
+    if (TCC == NULL) {
+      fprintf(stderr, "ERROR: Could not open TCC.framework");
+      exit(EXIT_FAILURE);
+    }
     int (*TCCAccessPreflight)(CFStringRef, CFDictionaryRef) = dlsym(TCC, "TCCAccessPreflight");
+    if (TCCAccessPreflight == NULL) {
+      fprintf(stderr, "ERROR: Could not get function TCCAccessPreflight");
+      exit(EXIT_FAILURE);
+    }
     dlclose(TCC);
 
     CFStringRef kTCCServiceAudioCapture = cfstring_from_cstr("kTCCServiceAudioCapture");

--- a/input/coreaudio_tap.m
+++ b/input/coreaudio_tap.m
@@ -1,3 +1,4 @@
+#include <CoreFoundation/CFBase.h>
 #import <Foundation/Foundation.h>
 
 #include <CoreAudio/AudioHardware.h>
@@ -9,6 +10,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <dlfcn.h>
 
 #include "input/common.h"
 #include "input/coreaudio_tap.h"
@@ -79,6 +81,19 @@ static bool source_is(const char *source, const char *value) {
 }
 
 int coreaudio_tap_source_enabled(const char *source) {
+    void* TCC = dlopen("/System/Library/PrivateFrameworks/TCC.framework/Versions/A/TCC", RTLD_NOW);
+    int (*TCCAccessPreflight)(CFStringRef, CFDictionaryRef) = dlsym(TCC, "TCCAccessPreflight");
+    dlclose(TCC);
+
+    CFStringRef kTCCServiceAudioCapture = cfstring_from_cstr("kTCCServiceAudioCapture");
+
+    if (TCCAccessPreflight(kTCCServiceAudioCapture, NULL) != 0) {
+      fprintf(stderr, "ERROR: AudioTap permissions missing! requesting...\n");
+      fprintf(stderr, "       Please add \"%s\" to the \"System Audio Recording Only\" section.\n", getenv("TERM_PROGRAM"));
+      system("/usr/bin/open x-apple.systempreferences:com.apple.settings.PrivacySecurity?Privacy_ScreenCapture");
+      exit(EXIT_FAILURE);
+    }
+
     if (source == NULL) {
         return 0;
     }


### PR DESCRIPTION
Using private apis found in TCC.framework, it is possible to detect whether system audio permissions have been granted to cava. It is not* possible to cause a system prompt to appear, because it requires a `NSAudioCaptureUsageDescription` key in the terminal emulator's `Info.plist`. It is possible to open the settings page by opening a link and prompt the user to grant permissions manually, which is what is done here.

<sub><sup>\*requires more digging</sup></sub>