### PR TITLE
Additional pipewire error handling

### DIFF
--- a/input/pipewire.c
+++ b/input/pipewire.c
@@ -75,13 +75,13 @@ static void on_stream_state_changed(void *_data, [[maybe_unused]] enum pw_stream
         break;
     case PW_STREAM_STATE_ERROR:
         sprintf(data->cava_audio->error_message,
-            __FILE__ ": Pipewire stream error. Is pipewire running?");
+                __FILE__ ": Pipewire stream error. Is pipewire running?");
         data->cava_audio->terminate = 1;
         pw_main_loop_quit(data->loop);
         break;
     case PW_STREAM_STATE_UNCONNECTED:
         sprintf(data->cava_audio->error_message,
-            __FILE__ ": Pipewire stream not connected. Is pipewire running?");
+                __FILE__ ": Pipewire stream not connected. Is pipewire running?");
         data->cava_audio->terminate = 1;
         pw_main_loop_quit(data->loop);
         break;

--- a/input/pipewire.c
+++ b/input/pipewire.c
@@ -74,7 +74,14 @@ static void on_stream_state_changed(void *_data, [[maybe_unused]] enum pw_stream
         pw_loop_update_timer(pw_main_loop_get_loop(data->loop), data->timer, NULL, NULL, false);
         break;
     case PW_STREAM_STATE_ERROR:
+        sprintf(data->cava_audio->error_message,
+            __FILE__ ": Pipewire stream error.");
+        data->cava_audio->terminate = 1;
+        pw_main_loop_quit(data->loop);
+        break;
     case PW_STREAM_STATE_UNCONNECTED:
+        sprintf(data->cava_audio->error_message,
+            __FILE__ ": Pipewire stream not connected.");
         data->cava_audio->terminate = 1;
         pw_main_loop_quit(data->loop);
         break;

--- a/input/pipewire.c
+++ b/input/pipewire.c
@@ -75,13 +75,13 @@ static void on_stream_state_changed(void *_data, [[maybe_unused]] enum pw_stream
         break;
     case PW_STREAM_STATE_ERROR:
         sprintf(data->cava_audio->error_message,
-            __FILE__ ": Pipewire stream error.");
+            __FILE__ ": Pipewire stream error. Is pipewire running?");
         data->cava_audio->terminate = 1;
         pw_main_loop_quit(data->loop);
         break;
     case PW_STREAM_STATE_UNCONNECTED:
         sprintf(data->cava_audio->error_message,
-            __FILE__ ": Pipewire stream not connected.");
+            __FILE__ ": Pipewire stream not connected. Is pipewire running?");
         data->cava_audio->terminate = 1;
         pw_main_loop_quit(data->loop);
         break;


### PR DESCRIPTION
Add error messages for exits due to stream failures. Avoids an otherwise graceful failure which returns mysterious messages to the user.

These messages can occur when pipewire is in use, so there is no 'maybe try pulse' hint like the other messages which can only occur if the server is missing.

Related: #771