### PR TITLE
feat: Implement horizontal_stereo and left_bottom in output config

### DIFF
--- a/cava.c
+++ b/cava.c
@@ -989,17 +989,28 @@ Keys:\n\
             memset(bars_left, 0, sizeof(float) * number_of_bars / output_channels);
             memset(bars_right, 0, sizeof(float) * number_of_bars / output_channels);
 
-            bars = (int *)malloc(number_of_bars * sizeof(int));
+            if (p.horizontal_stereo) {
+                bars = (int *)malloc(2 * number_of_bars * sizeof(int));
+                previous_frame = (int *)malloc(2 * number_of_bars * sizeof(int));
+            } else {
+                bars = (int *)malloc(number_of_bars * sizeof(int));
+                previous_frame = (int *)malloc(number_of_bars * sizeof(int));
+            }
             bars_raw = (float *)malloc(number_of_bars * sizeof(float));
             previous_bars_raw = (float *)malloc(number_of_bars * sizeof(float));
-            previous_frame = (int *)malloc(number_of_bars * sizeof(int));
             cava_out = (double *)malloc(number_of_bars * audio.channels / output_channels *
                                         sizeof(double));
 
-            memset(bars, 0, sizeof(int) * number_of_bars);
+            if (p.horizontal_stereo) {
+                memset(bars, 0, 2 * sizeof(int) * number_of_bars);
+                memset(previous_frame, 0, 2 * sizeof(int) * number_of_bars);
+            } else {
+                memset(bars, 0, sizeof(int) * number_of_bars);
+                memset(previous_frame, 0, sizeof(int) * number_of_bars);
+            }
+
             memset(bars_raw, 0, sizeof(float) * number_of_bars);
             memset(previous_bars_raw, 0, sizeof(float) * number_of_bars);
-            memset(previous_frame, 0, sizeof(int) * number_of_bars);
             memset(cava_out, 0, sizeof(double) * number_of_bars * audio.channels / output_channels);
 
             if (p.split_stereo) {
@@ -1458,7 +1469,7 @@ Keys:\n\
                                         bars_raw[number_of_bars - n - 1] = bars_right[n];
                                     }
                                 } else {
-                                    if (p.mono_opt == AVERAGE) {
+                                    if (p.mono_opt == AVERAGE && !p.horizontal_stereo) {
                                         bars_raw[n] = (bars_left[n] + bars_right[n]) / 2;
                                     } else if (p.mono_opt == LEFT) {
                                         bars_raw[n] = bars_left[n];
@@ -1474,11 +1485,22 @@ Keys:\n\
                 int re_paint = 0;
 #endif
                 for (int n = 0; n < number_of_bars; n++) {
-                    bars[n] = bars_raw[n];
+                    if (p.horizontal_stereo) {
+                        bars[n] = bars_left[n];
+                        bars[n + number_of_bars] = bars_right[n];
+                    } else {
+                        bars[n] = bars_raw[n];
+                    }
                     // show idle bar heads
                     if (output_mode != OUTPUT_RAW && output_mode != OUTPUT_NORITAKE &&
                         bars[n] < 1 && p.waveform == 0 && p.show_idle_bar_heads == 1)
                         bars[n] = 1;
+
+                    if (p.horizontal_stereo && output_mode != OUTPUT_RAW &&
+                        output_mode != OUTPUT_NORITAKE && bars[n + number_of_bars] < 1 &&
+                        p.waveform == 0 && p.show_idle_bar_heads == 1)
+                        bars[n + number_of_bars] = 1;
+
 #ifdef SDL_GLSL
 
                     if (output_mode == OUTPUT_SDL_GLSL)
@@ -1541,11 +1563,22 @@ Keys:\n\
                             }
 
                         } else {
-                            // pure mirrored split, same bars for both sides
                             if (p.orientation == ORIENT_SPLIT_H) {
-                                rc = draw_terminal_noncurses(bars, previous_frame, ORIENT_BOTTOM,
-                                                             &p);
-                                rc = draw_terminal_noncurses(bars, previous_frame, ORIENT_TOP, &p);
+                                if (p.horizontal_stereo) {
+                                    rc = draw_terminal_noncurses(bars, previous_frame,
+                                                                 ORIENT_BOTTOM, &p);
+                                    rc = draw_terminal_noncurses(bars + number_of_bars,
+                                                                 previous_frame + number_of_bars,
+                                                                 ORIENT_TOP, &p);
+                                }
+                                // pure mirrored split, same bars for both sides
+                                else {
+                                    rc = draw_terminal_noncurses(bars, previous_frame,
+                                                                 ORIENT_BOTTOM, &p);
+                                    rc = draw_terminal_noncurses(bars, previous_frame, ORIENT_TOP,
+                                                                 &p);
+                                }
+
                             } else if (p.orientation == ORIENT_SPLIT_V) {
                                 rc = draw_terminal_noncurses(bars, previous_frame, ORIENT_LEFT, &p);
                                 rc =
@@ -1601,7 +1634,12 @@ Keys:\n\
                     should_quit = true;
                 }
 
-                memcpy(previous_frame, bars, number_of_bars * sizeof(int));
+                if (p.horizontal_stereo) {
+                    memcpy(previous_frame, bars, 2 * number_of_bars * sizeof(int));
+                } else {
+                    memcpy(previous_frame, bars, number_of_bars * sizeof(int));
+                }
+
                 if (p.output == OUTPUT_SDL_GLSL) {
                     memcpy(previous_bars_raw, bars_raw, number_of_bars * sizeof(float));
                 }

--- a/config.c
+++ b/config.c
@@ -482,8 +482,12 @@ bool validate_config(struct config_params *p, struct error_s *error) {
             write_errorf(error, "only noncurses output supports horizontal stereo\n");
             return false;
         }
+        if (p->orientation != ORIENT_SPLIT_H) {
+            write_errorf(error, "only vertical orientation supports horizontal stereo\n");
+            return false;
+        }
         if (strcmp(monoOption, "average")) {
-            write_errorf(error, "horizontal stereo only supports mono option: average\n");
+            write_errorf(error, "only mono option average supports horizontal stereo\n");
             return false;
         }
     }

--- a/config.c
+++ b/config.c
@@ -476,8 +476,16 @@ bool validate_config(struct config_params *p, struct error_s *error) {
             return false;
         }
         p->orientation = ORIENT_SPLIT_V;
-        p->left_bottom = 1; // this setting is used to flip channels in horizontal split mode, makes
-                            // no sense here. forcing this to 1 puts left on left and right on right
+    }
+    if (p->horizontal_stereo) {
+        if (p->output != OUTPUT_NONCURSES) {
+            write_errorf(error, "only noncurses output supports horizontal stereo\n");
+            return false;
+        }
+        if (strcmp(monoOption, "average")) {
+            write_errorf(error, "horizontal stereo only supports mono option: average\n");
+            return false;
+        }
     }
     if (p->orientation != ORIENT_SPLIT_V && p->orientation != ORIENT_SPLIT_H) {
         p->split_stereo = 0;
@@ -855,6 +863,7 @@ bool load_config(char configPath[PATH_MAX], struct config_params *p, struct erro
     monoOption = strdup(iniparser_getstring(ini, "output:mono_option", "average"));
     p->reverse = iniparser_getint(ini, "output:reverse", 0);
     p->split_stereo = iniparser_getint(ini, "output:split_stereo", 0);
+    p->horizontal_stereo = iniparser_getint(ini, "output:horizontal_stereo", 0);
     p->left_bottom = iniparser_getint(ini, "output:left_bottom", 0);
     p->raw_target = strdup(iniparser_getstring(ini, "output:raw_target", "/dev/stdout"));
     p->data_format = strdup(iniparser_getstring(ini, "output:data_format", "binary"));
@@ -1050,6 +1059,9 @@ bool load_config(char configPath[PATH_MAX], struct config_params *p, struct erro
     p->frame_delim = (char)GetPrivateProfileInt("output", "frame_delimiter", 10, configPath);
     p->ascii_range = GetPrivateProfileInt("output", "ascii_max_range", 1000, configPath);
     p->bit_format = GetPrivateProfileInt("output", "bit_format", 16, configPath);
+
+    p->horizontal_stereo = GetPrivateProfileInt("output", "horizontal_stereo", 0, configPath);
+    p->left_bottom = GetPrivateProfileInt("output", "left_bottom", 0, configPath);
 
     p->sdl_width = GetPrivateProfileInt("output", "sdl_width", 1000, configPath);
     p->sdl_height = GetPrivateProfileInt("output", "sdl_height", 500, configPath);

--- a/config.h
+++ b/config.h
@@ -136,7 +136,7 @@ struct config_params {
         active, remix, virtual_node, samplerate, samplebits, channels, autoconnect, sleep_timer,
         live_config, sdl_width, sdl_height, sdl_x, sdl_y, sdl_full_screen, draw_and_quit, zero_test,
         non_zero_test, reverse, sync_updates, continuous_rendering, disable_blanking,
-        show_idle_bar_heads, waveform, center_align, split_stereo, left_bottom;
+        show_idle_bar_heads, waveform, center_align, split_stereo, horizontal_stereo, left_bottom;
 
     // non config params, used internally
     int number_of_bars;

--- a/example_files/config
+++ b/example_files/config
@@ -188,7 +188,7 @@
 
 # Only valid if orientation is set to 'horizontal'.
 # Set 'horizontal_stereo' to 1 to have left channel bars at top and right channel at bottom.
-# Set 'left_bottom' to 0 to have right channel at top and left channel at bottom.
+# Set 'left_bottom' to 1 to have right channel at top and left channel at bottom.
 ; horizontal_stereo = 0
 ; left_bottom = 1
 


### PR DESCRIPTION
This PR adds support for the horizontal_stereo option in example_files/config, which was previously unimplemented.

Based on my understanding (referencing cava's example config), horizontal_stereo renders the left and right channels on the top and bottom halves of the split view respectively. Therefore, mono must be set to average for this to work correctly.

The feature requires:
- orientation set to horizontal
- mono set to average

The left_bottom option defaults to 0. When set to 1, the left channel is placed on the bottom side and the right channel on the top side (i.e., the channels are swapped vertically).

<img width="1264" height="678" alt="cava_example" src="https://github.com/user-attachments/assets/641bc57b-9787-41ad-bd2a-01b76e07dbad" />
